### PR TITLE
TSDK-754 Start session pegout

### DIFF
--- a/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
+++ b/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
@@ -1,24 +1,25 @@
 package co.topl.bridge
 
-import munit.CatsEffectSuite
-import fs2.io.process
 import cats.effect.IO
-import org.http4s.ember.client._
-import org.http4s.Method
-import co.topl.shared.StartPeginSessionRequest
-import org.http4s.Request
-import org.http4s.Uri
-import org.http4s.EntityDecoder
-import co.topl.shared.StartSessionResponse
-import org.http4s.headers.`Content-Type`
-import org.checkerframework.checker.units.qual.g
+import co.topl.shared.BridgeContants
+import co.topl.shared.ConfirmDepositRequest
+import co.topl.shared.ConfirmDepositResponse
 import co.topl.shared.ConfirmRedemptionRequest
 import co.topl.shared.ConfirmRedemptionResponse
+import co.topl.shared.StartPeginSessionRequest
+import co.topl.shared.StartPeginSessionResponse
 import co.topl.shared.SyncWalletRequest
-import co.topl.shared.ConfirmDepositResponse
-import co.topl.shared.ConfirmDepositRequest
+import fs2.io.process
+import munit.CatsEffectSuite
+import org.checkerframework.checker.units.qual.g
+import org.http4s.EntityDecoder
+import org.http4s.Method
+import org.http4s.Request
+import org.http4s.Uri
+import org.http4s.ember.client._
+import org.http4s.headers.`Content-Type`
+
 import scala.concurrent.duration._
-import co.topl.shared.BridgeContants
 
 class BridgeIntegrationSpec extends CatsEffectSuite {
 
@@ -147,8 +148,8 @@ class BridgeIntegrationSpec extends CatsEffectSuite {
     implicit val syncWalletRequestDecoder
         : EntityEncoder[IO, SyncWalletRequest] =
       jsonEncoderOf[IO, SyncWalletRequest]
-    implicit val startSessionResponse: EntityDecoder[IO, StartSessionResponse] =
-      jsonOf[IO, StartSessionResponse]
+    implicit val startSessionResponse: EntityDecoder[IO, StartPeginSessionResponse] =
+      jsonOf[IO, StartPeginSessionResponse]
     implicit val confirmRedemptionRequestDecoder
         : EntityEncoder[IO, ConfirmRedemptionRequest] =
       jsonEncoderOf[IO, ConfirmRedemptionRequest]
@@ -190,7 +191,7 @@ class BridgeIntegrationSpec extends CatsEffectSuite {
           .default[IO]
           .build
           .use({ client =>
-            client.expect[StartSessionResponse](
+            client.expect[StartPeginSessionResponse](
               Request[IO](
                 method = Method.POST,
                 Uri

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
 
   lazy val toplOrg = "co.topl"
 
-  lazy val bramblVersion = "2.0.0-beta1"
+  lazy val bramblVersion = "2.0.0-beta3"
 
   val bramblSdk = toplOrg %% "brambl-sdk" % bramblVersion
 

--- a/shared/src/main/scala/co/topl/shared/BridgeContants.scala
+++ b/shared/src/main/scala/co/topl/shared/BridgeContants.scala
@@ -1,0 +1,7 @@
+package co.topl.shared
+
+object BridgeContants {
+  val START_PEGIN_SESSION_PATH = "/start-session-pegin"
+
+  val START_PEGOUT_SESSION_PATH = "/start-session-pegout"
+}

--- a/shared/src/main/scala/co/topl/shared/BridgeContants.scala
+++ b/shared/src/main/scala/co/topl/shared/BridgeContants.scala
@@ -1,7 +1,7 @@
 package co.topl.shared
 
 object BridgeContants {
-  val START_PEGIN_SESSION_PATH = "/start-session-pegin"
+  val START_PEGIN_SESSION_PATH = "start-session-pegin"
 
-  val START_PEGOUT_SESSION_PATH = "/start-session-pegout"
+  val START_PEGOUT_SESSION_PATH = "start-session-pegout"
 }

--- a/shared/src/main/scala/co/topl/shared/InputOutput.scala
+++ b/shared/src/main/scala/co/topl/shared/InputOutput.scala
@@ -1,6 +1,18 @@
 package co.topl.shared
 
-case class StartSessionRequest(
+/** This class is used to create a new session for a peg-in.
+  *
+  * @param pkey
+  *   The public key of the user.
+  * @param sha256
+  *   The hash of the secret that is used to redeem the peg-in.
+  */
+case class StartPeginSessionRequest(
+    pkey: String,
+    sha256: String
+)
+
+case class StartPegoutSessionRequest(
     pkey: String,
     sha256: String
 )

--- a/shared/src/main/scala/co/topl/shared/InputOutput.scala
+++ b/shared/src/main/scala/co/topl/shared/InputOutput.scala
@@ -13,7 +13,8 @@ case class StartPeginSessionRequest(
 )
 
 case class StartPegoutSessionRequest(
-    pkey: String,
+    userBaseKey: String,
+    currentHeight: Int,
     sha256: String
 )
 
@@ -21,11 +22,16 @@ case class SyncWalletRequest(
     secret: String
 )
 
-case class StartSessionResponse(
+case class StartPeginSessionResponse(
     sessionID: String,
     script: String,
     escrowAddress: String,
     descriptor: String
+)
+
+case class StartPegoutSessionResponse(
+    sessionID: String,
+    escrowAddress: String
 )
 
 case class ConfirmRedemptionRequest(
@@ -60,3 +66,4 @@ case class InvalidKey(error: String) extends BridgeError
 case class InvalidHash(error: String) extends BridgeError
 case class InvalidBase58(error: String) extends BridgeError
 case class InvalidInput(error: String) extends BridgeError
+case class WalletSetupError(error: String) extends BridgeError

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/Main.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/Main.scala
@@ -124,7 +124,6 @@ object Main
           case Right(value)         => Ok(value.asJson)
         }
       } yield resp
-    // TODO: Finish TSDK-754
     case req @ POST -> Root / BridgeContants.START_PEGOUT_SESSION_PATH =>
       import StartSessionController._
       implicit val startSessionRequestDecoder

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/Main.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/Main.scala
@@ -29,7 +29,7 @@ import co.topl.bridge.controllers.ConfirmRedemptionController
 import co.topl.bridge.controllers.StartSessionController
 import co.topl.bridge.managers.BTCWalletAlgebra
 import co.topl.bridge.managers.BTCWalletImpl
-import co.topl.bridge.managers.PeginSessionManagerImpl
+import co.topl.bridge.managers.SessionManagerImpl
 import co.topl.bridge.managers.SessionManagerAlgebra
 import co.topl.bridge.managers.ToplWalletAlgebra
 import co.topl.bridge.managers.ToplWalletImpl
@@ -138,7 +138,6 @@ object Main
           toplKeypair,
           toplWalletAlgebra,
           sessionManager,
-          x.currentHeight,
           1000
         )
         resp <- res match {
@@ -368,7 +367,7 @@ object Main
       )(_ => IO.unit)
       app = {
         val sessionManager =
-          PeginSessionManagerImpl.make[IO](new ConcurrentHashMap())
+          SessionManagerImpl.make[IO](new ConcurrentHashMap())
         val router = Router.define(
           "/" -> apiServices(
             walletApi,

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/Main.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/Main.scala
@@ -6,33 +6,46 @@ import cats.effect.IO
 import cats.effect.IOApp
 import cats.effect.kernel.Resource
 import co.topl.brambl.builders.TransactionBuilderApi
+import co.topl.brambl.codecs.AddressCodecs
 import co.topl.brambl.constants.NetworkConstants
 import co.topl.brambl.dataApi.GenusQueryAlgebra
 import co.topl.brambl.dataApi.RpcChannelResource
+import co.topl.brambl.dataApi.WalletStateAlgebra
+import co.topl.brambl.models.Indices
+import co.topl.brambl.models.LockAddress
+import co.topl.brambl.models.LockId
+import co.topl.brambl.servicekit.FellowshipStorageApi
+import co.topl.brambl.servicekit.TemplateStorageApi
 import co.topl.brambl.servicekit.WalletKeyApi
 import co.topl.brambl.servicekit.WalletStateApi
 import co.topl.brambl.servicekit.WalletStateResource
+import co.topl.brambl.utils.Encoding
 import co.topl.brambl.wallet.WalletApi
 import co.topl.bridge.BridgeParamsDescriptor
 import co.topl.bridge.ServerConfig
 import co.topl.bridge.ToplBTCBridgeParamConfig
+import co.topl.bridge.controllers.ConfirmDepositController
 import co.topl.bridge.controllers.ConfirmRedemptionController
 import co.topl.bridge.controllers.StartSessionController
-import co.topl.bridge.controllers.ConfirmDepositController
 import co.topl.bridge.managers.BTCWalletAlgebra
 import co.topl.bridge.managers.BTCWalletImpl
-import co.topl.bridge.managers.SessionManagerAlgebra
 import co.topl.bridge.managers.PeginSessionManagerImpl
+import co.topl.bridge.managers.SessionManagerAlgebra
 import co.topl.bridge.managers.ToplWalletAlgebra
 import co.topl.bridge.managers.ToplWalletImpl
 import co.topl.bridge.managers.TransactionAlgebra
 import co.topl.bridge.managers.WalletManagementUtils
+import co.topl.genus.services.Txo
+import co.topl.genus.services.TxoState
 import co.topl.shared.BitcoinNetworkIdentifiers
+import co.topl.shared.BridgeContants
 import co.topl.shared.BridgeError
 import co.topl.shared.ConfirmDepositRequest
 import co.topl.shared.ConfirmRedemptionRequest
 import co.topl.shared.SessionNotFoundError
 import co.topl.shared.StartPeginSessionRequest
+import co.topl.shared.SyncWalletRequest
+import co.topl.shared.ToplNetworkIdentifiers
 import co.topl.shared.utils.KeyGenerationUtils
 import io.circe.generic.auto._
 import io.circe.syntax._
@@ -44,21 +57,11 @@ import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.server.Router
 import org.http4s.server.staticcontent.resourceServiceBuilder
 import quivr.models.KeyPair
+import quivr.models.VerificationKey
 import scopt.OParser
 
 import java.util.concurrent.ConcurrentHashMap
-import co.topl.shared.ToplNetworkIdentifiers
-import co.topl.brambl.dataApi.WalletStateAlgebra
-import co.topl.brambl.codecs.AddressCodecs
-import co.topl.genus.services.TxoState
-import co.topl.genus.services.Txo
-import co.topl.brambl.models.Indices
-import co.topl.brambl.models.LockAddress
-import co.topl.brambl.utils.Encoding
-import co.topl.brambl.models.LockId
-import quivr.models.VerificationKey
-import co.topl.shared.SyncWalletRequest
-import co.topl.shared.BridgeContants
+import co.topl.shared.StartPegoutSessionRequest
 
 object Main
     extends IOApp
@@ -121,25 +124,31 @@ object Main
           case Right(value)         => Ok(value.asJson)
         }
       } yield resp
+    // TODO: Finish TSDK-754
     case req @ POST -> Root / BridgeContants.START_PEGOUT_SESSION_PATH =>
       import StartSessionController._
       implicit val startSessionRequestDecoder
-          : EntityDecoder[IO, StartPeginSessionRequest] =
-        jsonOf[IO, StartPeginSessionRequest]
-      for {
-        x <- req.as[StartPeginSessionRequest]
-        res <- startPeginSession(
+          : EntityDecoder[IO, StartPegoutSessionRequest] =
+        jsonOf[IO, StartPegoutSessionRequest]
+      (for {
+        x <- req.as[StartPegoutSessionRequest]
+        res <- startPegoutSession(
           x,
-          pegInWalletManager,
+          toplNetwork,
+          toplKeypair,
+          toplWalletAlgebra,
           sessionManager,
-          blockToRecover,
-          btcNetwork
+          x.currentHeight,
+          1000
         )
         resp <- res match {
           case Left(e: BridgeError) => BadRequest(e.asJson)
           case Right(value)         => Ok(value.asJson)
         }
-      } yield resp
+      } yield resp).handleErrorWith { case e =>
+        e.printStackTrace()
+        BadRequest("Error starting pegout session")
+      }
     case req @ POST -> Root / "confirm-deposit" =>
       implicit val confirmDepositRequestDecoder
           : EntityDecoder[IO, ConfirmDepositRequest] =
@@ -265,7 +274,9 @@ object Main
           ), // lockPredicate
           lockAddress.toBase58(), // lockAddress
           Some("ExtendedEd25519"),
-          Some(Encoding.encodeToBase58(vksDerived.head.toByteArray)), // TODO: we assume here only one party, fix this later
+          Some(
+            Encoding.encodeToBase58(vksDerived.head.toByteArray)
+          ), // TODO: we assume here only one party, fix this later
           indices
         )
       } yield txos
@@ -330,6 +341,8 @@ object Main
       toplWalletImpl = ToplWalletImpl.make[IO](
         IO.asyncForIO,
         walletApi,
+        FellowshipStorageApi.make(walletResource(params.toplWalletDb)),
+        TemplateStorageApi.make(walletResource(params.toplWalletDb)),
         walletStateAlgebra,
         transactionBuilderApi,
         genusQueryAlgebra

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/controllers/StartSessionController.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/controllers/StartSessionController.scala
@@ -117,7 +117,6 @@ object StartSessionController {
       keyPair: KeyPair,
       toplWalletAlgebra: ToplWalletAlgebra[F],
       sessionManager: SessionManagerAlgebra[F],
-      currentBlockHeight: Int,
       waitTime: Int
   ): F[Either[BridgeError, StartPegoutSessionResponse]] = {
     import cats.implicits._
@@ -131,7 +130,7 @@ object StartSessionController {
           fellowshipId,
           req.sha256,
           waitTime,
-          currentBlockHeight
+          req.currentHeight
         )
         .map(_.getOrElse(throw new WalletSetupError("Failed to create wallet")))
       sessionInfo = PegoutSessionInfo(

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/managers/SessionManager.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/managers/SessionManager.scala
@@ -21,7 +21,7 @@ case class PeginSessionInfo(
 
 case class PegoutSessionInfo(
     bridgeFellowshipId: String,
-    quivrScript: String
+    address: String
 ) extends SessionInfo
 
 trait SessionManagerAlgebra[F[_]] {
@@ -34,7 +34,7 @@ trait SessionManagerAlgebra[F[_]] {
   ): F[SessionInfo]
 }
 
-object PeginSessionManagerImpl {
+object SessionManagerImpl {
   def make[F[_]: Sync](
       map: ConcurrentMap[String, SessionInfo]
   ): SessionManagerAlgebra[F] = new SessionManagerAlgebra[F] {

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/managers/SessionManager.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/managers/SessionManager.scala
@@ -5,32 +5,42 @@ import cats.effect.kernel.Sync
 import java.util.UUID
 import java.util.concurrent.ConcurrentMap
 
+/**
+  * This class is used to store the session information for a pegin.
+  *
+  * @param currentWalletIdx The index of the wallet that is currently being used.
+  * @param scriptAsm The script that is used to redeem the pegin.
+  */
+case class PeginSessionInfo(
+    currentWalletIdx: Int,
+    scriptAsm: String,
+)
 
-case class SessionInfo(
+case class PegoutSessionInfo(
     bridgePKey: String,
     currentWalletIdx: Int,
     userPKey: String,
     secretHash: String,
-    scriptAsm: String,
+    quivrScript: String,
     address: String
 )
 
 trait SessionManagerAlgebra[F[_]] {
   def createNewSession(
-      sessionInfo: SessionInfo
+      sessionInfo: PeginSessionInfo
   ): F[String]
 
   def getSession(
       sessionId: String
-  ): F[SessionInfo]
+  ): F[PeginSessionInfo]
 }
 
-object SessionManagerImpl {
+object PeginSessionManagerImpl {
   def make[F[_]: Sync](
-      map: ConcurrentMap[String, SessionInfo]
+      map: ConcurrentMap[String, PeginSessionInfo]
   ): SessionManagerAlgebra[F] = new SessionManagerAlgebra[F] {
     def createNewSession(
-        sessionInfo: SessionInfo
+        sessionInfo: PeginSessionInfo
     ): F[String] = {
       import cats.implicits._
       for {
@@ -41,7 +51,7 @@ object SessionManagerImpl {
 
     def getSession(
         sessionId: String
-    ): F[SessionInfo] = {
+    ): F[PeginSessionInfo] = {
       Sync[F].fromOption(
         {
           Option(map.get(sessionId))

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/managers/ToplWalletAlgebra.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/managers/ToplWalletAlgebra.scala
@@ -6,11 +6,11 @@ import co.topl.brambl.builders.TransactionBuilderApi
 import co.topl.brambl.dataApi.GenusQueryAlgebra
 import co.topl.brambl.dataApi.WalletStateAlgebra
 import co.topl.brambl.models.box.AssetMintingStatement
+import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.wallet.WalletApi
 import co.topl.genus.services.Txo
 import com.google.protobuf.ByteString
 import io.circe.Json
-import co.topl.brambl.models.transaction.IoTransaction
 import quivr.models.KeyPair
 
 trait ToplWalletAlgebra[F[_]] {
@@ -25,6 +25,8 @@ trait ToplWalletAlgebra[F[_]] {
       commitment: Option[ByteString],
       assetMintingStatement: AssetMintingStatement
   ): F[IoTransaction]
+
+  def getCurrentPubKeyAndPrepareNext(): F[(Int, String)]
 
 }
 
@@ -50,6 +52,22 @@ object ToplWalletImpl {
     val tba = transactionBuilderApi
 
     val wa = walletApi
+
+    def getCurrentPubKeyAndPrepareNext(): F[(Int, String)] = {
+      for {
+        someIndex <- walletStateApi.getCurrentIndicesForFunds(
+          "self",
+          "default",
+          None
+        )
+      } yield ???
+    }
+    // {
+    //   for {
+    //     idx <- currentIdx.getAndUpdate(_ + 1)
+    //     pubKey <- KeyGenerationUtils.generateKey(km, idx)
+    //   } yield (idx, pubKey)
+    // }
 
     private def sharedOps(
         fromFellowship: String,

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/managers/ToplWalletAlgebra.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/managers/ToplWalletAlgebra.scala
@@ -1,17 +1,28 @@
 package co.topl.bridge.managers
 
 import cats.Monad
+import cats.data.OptionT
 import cats.effect.kernel.Sync
 import co.topl.brambl.builders.TransactionBuilderApi
+import co.topl.brambl.constants.NetworkConstants
+import co.topl.brambl.dataApi.FellowshipStorageAlgebra
 import co.topl.brambl.dataApi.GenusQueryAlgebra
+import co.topl.brambl.dataApi.TemplateStorageAlgebra
+import co.topl.brambl.dataApi.WalletFellowship
 import co.topl.brambl.dataApi.WalletStateAlgebra
+import co.topl.brambl.dataApi.WalletTemplate
+import co.topl.brambl.models.LockAddress
+import co.topl.brambl.models.LockId
 import co.topl.brambl.models.box.AssetMintingStatement
 import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.brambl.utils.Encoding
 import co.topl.brambl.wallet.WalletApi
 import co.topl.genus.services.Txo
+import co.topl.shared.ToplNetworkIdentifiers
 import com.google.protobuf.ByteString
 import io.circe.Json
 import quivr.models.KeyPair
+import quivr.models.VerificationKey
 
 trait ToplWalletAlgebra[F[_]] {
 
@@ -26,7 +37,15 @@ trait ToplWalletAlgebra[F[_]] {
       assetMintingStatement: AssetMintingStatement
   ): F[IoTransaction]
 
-  def getCurrentPubKeyAndPrepareNext(): F[(Int, String)]
+  def setupBridgeWallet(
+      networkId: ToplNetworkIdentifiers,
+      keyPair: KeyPair,
+      userBaseKey: String,
+      sessionId: String,
+      sha256: String,
+      waitTime: Int,
+      currentHeight: Int
+  ): F[Option[String]]
 
 }
 
@@ -36,6 +55,8 @@ object ToplWalletImpl {
   def make[F[_]](
       psync: Sync[F],
       walletApi: WalletApi[F],
+      fellowshipStorageAlgebra: FellowshipStorageAlgebra[F],
+      templateStorageAlgebra: TemplateStorageAlgebra[F],
       walletStateApi: WalletStateAlgebra[F],
       transactionBuilderApi: TransactionBuilderApi[F],
       utxoAlgebra: GenusQueryAlgebra[F]
@@ -53,22 +74,145 @@ object ToplWalletImpl {
 
     val wa = walletApi
 
-    def getCurrentPubKeyAndPrepareNext(): F[(Int, String)] = {
-      for {
-        someIndex <- walletStateApi.getCurrentIndicesForFunds(
-          "self",
-          "default",
-          None
-        )
-      } yield ???
-    }
-    // {
-    //   for {
-    //     idx <- currentIdx.getAndUpdate(_ + 1)
-    //     pubKey <- KeyGenerationUtils.generateKey(km, idx)
-    //   } yield (idx, pubKey)
-    // }
+    val templateName = "bridgeTemplate"
 
+    private def computeSerializedTemplate(
+        sha256: String,
+        waitTime: Int,
+        currentHeight: Int
+    ) =
+      for {
+        decodedHex <- OptionT(
+          Sync[F].delay(
+            Encoding.decodeFromHex(sha256).toOption
+          )
+        )
+        lockTemplateAsJson <- OptionT(Sync[F].delay(s"""{
+                "threshold":1,
+                "innerTemplates":[
+                  {
+                    "left": {"routine":"ExtendedEd25519","entityIdx":0,"type":"signature"},
+                    "right": {"chain":"header","min": ${currentHeight + waitTime + 1},"max":9223372036854775807,"type":"height"},
+                    "type": "and"
+                  },
+                  {
+                    "left": {"chain":"header","min": ${currentHeight},"max": ${currentHeight + waitTime},"type":"height"},
+                    "right": {
+                      "type": "and",
+                      "left": {"routine":"ExtendedEd25519","entityIdx":1,"type":"signature"},
+                      "right": {"routine":"Sha256","digest": "${Encoding
+            .encodeToBase58(decodedHex)}","type":"digest"}
+                    },
+                    "type": "and"
+                  }
+                ],
+                "type":"predicate"}
+              """.some))
+      } yield lockTemplateAsJson
+
+    def setupBridgeWallet(
+        networkId: ToplNetworkIdentifiers,
+        keypair: KeyPair,
+        userBaseKey: String,
+        sessionId: String,
+        sha256: String,
+        waitTime: Int,
+        currentHeight: Int
+    ): F[Option[String]] = {
+
+      import cats.implicits._
+      import co.topl.brambl.common.ContainsEvidence.Ops
+      import co.topl.brambl.common.ContainsImmutable.instances._
+      import TransactionBuilderApi.implicits._
+      implicit class ImplicitConversion[A](x: F[A]) {
+        def optionT = OptionT(x.map(_.some))
+      }
+      implicit class ImplicitConversion1[A](x: F[Option[A]]) {
+        def liftT = OptionT(x)
+      }
+      (for {
+        _ <-
+          fellowshipStorageAlgebra
+            .addFellowship(
+              WalletFellowship(0, sessionId)
+            )
+            .optionT
+        lockTemplateAsJson <- computeSerializedTemplate(
+          sha256,
+          waitTime,
+          currentHeight
+        )
+        _ <- templateStorageAlgebra
+          .addTemplate(
+            WalletTemplate(0, templateName, lockTemplateAsJson)
+          )
+          .optionT
+        indices <- walletStateApi
+          .getCurrentIndicesForFunds(
+            sessionId,
+            templateName,
+            None
+          )
+          .liftT
+        userVk <- walletApi
+          .deriveChildVerificationKey(
+            VerificationKey.parseFrom(
+              Encoding.decodeFromBase58(userBaseKey).toOption.get
+            ),
+            1
+          )
+          .optionT
+        lockTempl <- walletStateApi
+          .getLockTemplate(templateName)
+          .liftT
+        deriveChildKeyUserString = Encoding.encodeToBase58(
+          userVk.toByteArray
+        )
+        bridgeKey <- walletApi
+          .deriveChildKeys(keypair, indices)
+          .map(_.vk)
+          .optionT
+        deriveChildKeyBridgeString = Encoding.encodeToBase58(
+          bridgeKey.toByteArray
+        )
+        lock <- lockTempl
+          .build(
+            userVk :: bridgeKey :: Nil
+          )
+          .map(_.toOption)
+          .liftT
+        lockAddress = LockAddress(
+          networkId.networkId,
+          NetworkConstants.MAIN_LEDGER_ID,
+          LockId(lock.sizedEvidence.digest.value)
+        )
+        _ <- walletStateApi
+          .updateWalletState(
+            Encoding.encodeToBase58Check(
+              lock.getPredicate.toByteArray
+            ), // lockPredicate
+            lockAddress.toBase58(), // lockAddress
+            Some("ExtendedEd25519"),
+            Some(deriveChildKeyBridgeString),
+            indices
+          )
+          .optionT
+        _ <- walletStateApi
+          .addEntityVks(
+            sessionId,
+            templateName,
+            deriveChildKeyUserString :: deriveChildKeyBridgeString :: Nil
+          )
+          .optionT
+        currentAddress <- walletStateApi
+          .getAddress(
+            sessionId,
+            templateName,
+            None
+          )
+          .liftT
+      } yield currentAddress).value
+    }
     private def sharedOps(
         fromFellowship: String,
         fromTemplate: String,

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/controllers/ConfirmRedemptionControllerSpec.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/controllers/ConfirmRedemptionControllerSpec.scala
@@ -2,16 +2,16 @@ package co.topl.bridge.controllers
 
 import cats.effect.IO
 import co.topl.bridge.managers.BTCWalletImpl
-import co.topl.bridge.managers.PeginSessionInfo
 import co.topl.bridge.managers.PeginSessionManagerImpl
+import co.topl.bridge.managers.SessionInfo
+import co.topl.shared.ConfirmRedemptionRequest
 import co.topl.shared.RegTest
+import co.topl.shared.SessionNotFoundError
 import co.topl.shared.StartPeginSessionRequest
 import co.topl.shared.utils.KeyGenerationUtils
 import munit.CatsEffectSuite
 
 import java.util.concurrent.ConcurrentHashMap
-import co.topl.shared.ConfirmRedemptionRequest
-import co.topl.shared.SessionNotFoundError
 
 class ConfirmRedemptionControllerSpec extends CatsEffectSuite with SharedData {
 
@@ -34,7 +34,7 @@ class ConfirmRedemptionControllerSpec extends CatsEffectSuite with SharedData {
         wallet <- BTCWalletImpl.make[IO](km1)
         currentPubKey <- peginWallet.getCurrentPubKey()
         sessionManager = PeginSessionManagerImpl.make[IO](
-          new ConcurrentHashMap[String, PeginSessionInfo]()
+          new ConcurrentHashMap[String, SessionInfo]()
         )
         sessionInfo <- StartSessionController.startPeginSession(
           StartPeginSessionRequest(
@@ -81,7 +81,7 @@ class ConfirmRedemptionControllerSpec extends CatsEffectSuite with SharedData {
         wallet <- BTCWalletImpl.make[IO](km1)
         currentPubKey <- peginWallet.getCurrentPubKey()
         sessionManager = PeginSessionManagerImpl.make[IO](
-          new ConcurrentHashMap[String, PeginSessionInfo]()
+          new ConcurrentHashMap[String, SessionInfo]()
         )
         res <- ConfirmRedemptionController.confirmRedemption(
           ConfirmRedemptionRequest(

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/controllers/ConfirmRedemptionControllerSpec.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/controllers/ConfirmRedemptionControllerSpec.scala
@@ -2,7 +2,7 @@ package co.topl.bridge.controllers
 
 import cats.effect.IO
 import co.topl.bridge.managers.BTCWalletImpl
-import co.topl.bridge.managers.PeginSessionManagerImpl
+import co.topl.bridge.managers.SessionManagerImpl
 import co.topl.bridge.managers.SessionInfo
 import co.topl.shared.ConfirmRedemptionRequest
 import co.topl.shared.RegTest
@@ -33,7 +33,7 @@ class ConfirmRedemptionControllerSpec extends CatsEffectSuite with SharedData {
         )
         wallet <- BTCWalletImpl.make[IO](km1)
         currentPubKey <- peginWallet.getCurrentPubKey()
-        sessionManager = PeginSessionManagerImpl.make[IO](
+        sessionManager = SessionManagerImpl.make[IO](
           new ConcurrentHashMap[String, SessionInfo]()
         )
         sessionInfo <- StartSessionController.startPeginSession(
@@ -80,7 +80,7 @@ class ConfirmRedemptionControllerSpec extends CatsEffectSuite with SharedData {
         )
         wallet <- BTCWalletImpl.make[IO](km1)
         currentPubKey <- peginWallet.getCurrentPubKey()
-        sessionManager = PeginSessionManagerImpl.make[IO](
+        sessionManager = SessionManagerImpl.make[IO](
           new ConcurrentHashMap[String, SessionInfo]()
         )
         res <- ConfirmRedemptionController.confirmRedemption(

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/controllers/ConfirmRedemptionControllerSpec.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/controllers/ConfirmRedemptionControllerSpec.scala
@@ -2,10 +2,10 @@ package co.topl.bridge.controllers
 
 import cats.effect.IO
 import co.topl.bridge.managers.BTCWalletImpl
-import co.topl.bridge.managers.SessionInfo
-import co.topl.bridge.managers.SessionManagerImpl
+import co.topl.bridge.managers.PeginSessionInfo
+import co.topl.bridge.managers.PeginSessionManagerImpl
 import co.topl.shared.RegTest
-import co.topl.shared.StartSessionRequest
+import co.topl.shared.StartPeginSessionRequest
 import co.topl.shared.utils.KeyGenerationUtils
 import munit.CatsEffectSuite
 
@@ -33,11 +33,11 @@ class ConfirmRedemptionControllerSpec extends CatsEffectSuite with SharedData {
         )
         wallet <- BTCWalletImpl.make[IO](km1)
         currentPubKey <- peginWallet.getCurrentPubKey()
-        sessionManager = SessionManagerImpl.make[IO](
-          new ConcurrentHashMap[String, SessionInfo]()
+        sessionManager = PeginSessionManagerImpl.make[IO](
+          new ConcurrentHashMap[String, PeginSessionInfo]()
         )
-        sessionInfo <- StartSessionController.startSession(
-          StartSessionRequest(
+        sessionInfo <- StartSessionController.startPeginSession(
+          StartPeginSessionRequest(
             testKey,
             testHash
           ),
@@ -80,8 +80,8 @@ class ConfirmRedemptionControllerSpec extends CatsEffectSuite with SharedData {
         )
         wallet <- BTCWalletImpl.make[IO](km1)
         currentPubKey <- peginWallet.getCurrentPubKey()
-        sessionManager = SessionManagerImpl.make[IO](
-          new ConcurrentHashMap[String, SessionInfo]()
+        sessionManager = PeginSessionManagerImpl.make[IO](
+          new ConcurrentHashMap[String, PeginSessionInfo]()
         )
         res <- ConfirmRedemptionController.confirmRedemption(
           ConfirmRedemptionRequest(

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/controllers/SharedData.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/controllers/SharedData.scala
@@ -7,6 +7,9 @@ trait SharedData {
   val testKey =
     "0295bb5a3b80eeccb1e38ab2cbac2545e9af6c7012cdc8d53bd276754c54fc2e4a"
 
+  val pegoutTestKey =
+    "GeMD3jTdhpE1zpMBPwJWj2gUrFG5GxkFAc8GFDqjUaXXH2TyXXaDjmrxcnA18JUkgWFxBAzkuiQzJPbh3QdQoKg1oW4fbP3nn2"
+
   val testHash =
     "497a39b618484855ebb5a2cabf6ee52ff092e7c17f8bfe79313529f9774f83a2"
 
@@ -18,6 +21,10 @@ trait SharedData {
   val walletFile = "src/test/resources/wallet.json"
 
   val toplWalletFile = "src/test/resources/topl-wallet.json"
+  
+  val toplWalletDbInitial = "src/universal/topl-wallet.db"
+
+  val toplWalletDb = "src/universal/topl-wallet-instance.db"
 
   val testSecret = "secret"
 

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/controllers/SharedData.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/controllers/SharedData.scala
@@ -13,9 +13,9 @@ trait SharedData {
   val testInputTx =
     "08d9a63c8e05945d83dd8460d9418e506beb041dd719104108fc53733e8de1d0"
 
-  val peginWalletFile = "topl-btc-bridge/src/test/resources/pegin-wallet.json"
+  val peginWalletFile = "src/test/resources/pegin-wallet.json"
 
-  val walletFile = "topl-btc-bridge/src/test/resources/wallet.json"
+  val walletFile = "src/test/resources/wallet.json"
 
   val toplWalletFile = "src/test/resources/topl-wallet.json"
 

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/controllers/StartSessionControllerSpec.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/controllers/StartSessionControllerSpec.scala
@@ -5,17 +5,48 @@ import co.topl.shared.utils.KeyGenerationUtils
 import co.topl.shared.RegTest
 import co.topl.bridge.managers.BTCWalletImpl
 import cats.effect.IO
-import co.topl.bridge.managers.PeginSessionManagerImpl
+import co.topl.bridge.managers.SessionManagerImpl
 import java.util.concurrent.ConcurrentHashMap
 import co.topl.bridge.managers.PeginSessionInfo
 import co.topl.shared.StartPeginSessionRequest
 import co.topl.shared.InvalidKey
 import co.topl.shared.InvalidHash
 import co.topl.bridge.managers.SessionInfo
+import co.topl.shared.ToplPrivatenet
+import co.topl.shared.StartPegoutSessionRequest
+import co.topl.brambl.wallet.WalletApi
+import co.topl.brambl.servicekit.WalletKeyApi
+import co.topl.bridge.managers.WalletManagementUtils
+import co.topl.bridge.managers.ToplWalletImpl
+import co.topl.brambl.servicekit.FellowshipStorageApi
+import co.topl.brambl.servicekit.TemplateStorageApi
+import co.topl.brambl.servicekit.WalletStateResource
+import co.topl.brambl.servicekit.WalletStateApi
+import co.topl.brambl.builders.TransactionBuilderApi
+import co.topl.brambl.constants.NetworkConstants
+import co.topl.brambl.dataApi.GenusQueryAlgebra
+import co.topl.brambl.dataApi.RpcChannelResource
+import co.topl.bridge.managers.PegoutSessionInfo
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.Files
+import co.topl.shared.InvalidInput
 
-class StartSessionControllerSpec extends CatsEffectSuite with SharedData {
+class StartSessionControllerSpec
+    extends CatsEffectSuite
+    with WalletStateResource
+    with RpcChannelResource
+    with SharedData {
 
-  test("StartSessionController should start a session") {
+  val tmpDirectory = FunFixture[Path](
+    setup = { _ =>
+      val initialWalletDb = Paths.get(toplWalletDbInitial)
+      Files.copy(initialWalletDb, Paths.get(toplWalletDb))
+    },
+    teardown = { f => Files.delete(f) }
+  )
+
+  test("StartSessionController should start a pegin session") {
     assertIOBoolean(
       for {
         km0 <- KeyGenerationUtils.createKeyManager[IO](
@@ -25,7 +56,7 @@ class StartSessionControllerSpec extends CatsEffectSuite with SharedData {
         )
         peginWallet <- BTCWalletImpl.make[IO](km0)
         currentPubKey <- peginWallet.getCurrentPubKey()
-        sessionManager = PeginSessionManagerImpl.make[IO](
+        sessionManager = SessionManagerImpl.make[IO](
           new ConcurrentHashMap[String, SessionInfo]()
         )
         res <- StartSessionController.startPeginSession(
@@ -40,12 +71,126 @@ class StartSessionControllerSpec extends CatsEffectSuite with SharedData {
         )
         sessionInfo <- sessionManager.getSession(res.toOption.get.sessionID)
       } yield (sessionInfo.asInstanceOf[PeginSessionInfo].currentWalletIdx == 0)
-        // (sessionInfo.userPKey == testKey)
-        // (sessionInfo.bridgePKey == currentPubKey.hex)
     )
   }
 
-  test("StartSessionController should fai with invalid key") {
+  tmpDirectory.test("StartSessionController should start a pegout session") {
+    _ =>
+      val walletKeyApi = WalletKeyApi.make[IO]()
+      val walletApi = WalletApi.make[IO](walletKeyApi)
+      val walletManagementUtils = new WalletManagementUtils(
+        walletApi,
+        walletKeyApi
+      )
+      val walletStateAlgebra = WalletStateApi
+        .make[IO](walletResource(toplWalletDb), walletApi)
+      val transactionBuilderApi = TransactionBuilderApi.make[IO](
+        ToplPrivatenet.networkId,
+        NetworkConstants.MAIN_LEDGER_ID
+      )
+      val genusQueryAlgebra = GenusQueryAlgebra.make[IO](
+        channelResource(
+          "localhost",
+          9084,
+          false
+        )
+      )
+      val sessionManager = SessionManagerImpl.make[IO](
+        new ConcurrentHashMap[String, SessionInfo]()
+      )
+      assertIOBoolean(
+        for {
+          keypair <- walletManagementUtils.loadKeys(
+            toplWalletFile,
+            testToplPassword
+          )
+          toplWalletImpl = ToplWalletImpl.make[IO](
+            IO.asyncForIO,
+            walletApi,
+            FellowshipStorageApi.make(walletResource(toplWalletDb)),
+            TemplateStorageApi.make(walletResource(toplWalletDb)),
+            walletStateAlgebra,
+            transactionBuilderApi,
+            genusQueryAlgebra
+          )
+          res <- StartSessionController.startPegoutSession[IO](
+            StartPegoutSessionRequest(
+              pegoutTestKey,
+              1000,
+              testHash
+            ),
+            ToplPrivatenet,
+            keypair, // keypair
+            toplWalletImpl, // toplWalletAlgebra
+            sessionManager, // session manager
+            1000
+          )
+          sessionInfo <- sessionManager.getSession(res.toOption.get.sessionID)
+        } yield (sessionInfo
+          .asInstanceOf[PegoutSessionInfo]
+          .address == "ptetP7jshHVPgNWRFrYBAMCrnfAwpRn6hSNuAcMfgukVtA1x3wkjCPqqwD7w")
+      )
+  }
+
+  tmpDirectory.test(
+    "StartSessionController should fail with invalid key (pegout)"
+  ) { _ =>
+    val walletKeyApi = WalletKeyApi.make[IO]()
+    val walletApi = WalletApi.make[IO](walletKeyApi)
+    val walletManagementUtils = new WalletManagementUtils(
+      walletApi,
+      walletKeyApi
+    )
+    val walletStateAlgebra = WalletStateApi
+      .make[IO](walletResource(toplWalletDb), walletApi)
+    val transactionBuilderApi = TransactionBuilderApi.make[IO](
+      ToplPrivatenet.networkId,
+      NetworkConstants.MAIN_LEDGER_ID
+    )
+    val genusQueryAlgebra = GenusQueryAlgebra.make[IO](
+      channelResource(
+        "localhost",
+        9084,
+        false
+      )
+    )
+    val sessionManager = SessionManagerImpl.make[IO](
+      new ConcurrentHashMap[String, SessionInfo]()
+    )
+    assertIOBoolean(
+      for {
+        keypair <- walletManagementUtils.loadKeys(
+          toplWalletFile,
+          testToplPassword
+        )
+        toplWalletImpl = ToplWalletImpl.make[IO](
+          IO.asyncForIO,
+          walletApi,
+          FellowshipStorageApi.make(walletResource(toplWalletDb)),
+          TemplateStorageApi.make(walletResource(toplWalletDb)),
+          walletStateAlgebra,
+          transactionBuilderApi,
+          genusQueryAlgebra
+        )
+        res <- StartSessionController.startPegoutSession[IO](
+          StartPegoutSessionRequest(
+            "invalidKey",
+            1000,
+            testHash
+          ),
+          ToplPrivatenet,
+          keypair, // keypair
+          toplWalletImpl, // toplWalletAlgebra
+          sessionManager, // session manager
+          1000
+        )
+      } yield res.isLeft && res.swap.toOption.get == InvalidKey(
+        "Invalid key invalidKey"
+      )
+    )
+  }
+
+  test("StartSessionController should fai with invalid key (pegin)") {
     assertIOBoolean(
       for {
         km0 <- KeyGenerationUtils.createKeyManager[IO](
@@ -55,7 +200,7 @@ class StartSessionControllerSpec extends CatsEffectSuite with SharedData {
         )
         peginWallet <- BTCWalletImpl.make[IO](km0)
         currentPubKey <- peginWallet.getCurrentPubKey()
-        sessionManager = PeginSessionManagerImpl.make[IO](
+        sessionManager = SessionManagerImpl.make[IO](
           new ConcurrentHashMap[String, SessionInfo]()
         )
         res <- StartSessionController.startPeginSession(
@@ -84,7 +229,7 @@ class StartSessionControllerSpec extends CatsEffectSuite with SharedData {
         )
         peginWallet <- BTCWalletImpl.make[IO](km0)
         currentPubKey <- peginWallet.getCurrentPubKey()
-        sessionManager = PeginSessionManagerImpl.make[IO](
+        sessionManager = SessionManagerImpl.make[IO](
           new ConcurrentHashMap[String, SessionInfo]()
         )
         res <- StartSessionController.startPeginSession(
@@ -102,4 +247,121 @@ class StartSessionControllerSpec extends CatsEffectSuite with SharedData {
       )
     )
   }
+
+  tmpDirectory.test(
+    "StartSessionController should fail with invalid hash (pegout)"
+  ) { _ =>
+    val walletKeyApi = WalletKeyApi.make[IO]()
+    val walletApi = WalletApi.make[IO](walletKeyApi)
+    val walletManagementUtils = new WalletManagementUtils(
+      walletApi,
+      walletKeyApi
+    )
+    val walletStateAlgebra = WalletStateApi
+      .make[IO](walletResource(toplWalletDb), walletApi)
+    val transactionBuilderApi = TransactionBuilderApi.make[IO](
+      ToplPrivatenet.networkId,
+      NetworkConstants.MAIN_LEDGER_ID
+    )
+    val genusQueryAlgebra = GenusQueryAlgebra.make[IO](
+      channelResource(
+        "localhost",
+        9084,
+        false
+      )
+    )
+    val sessionManager = SessionManagerImpl.make[IO](
+      new ConcurrentHashMap[String, SessionInfo]()
+    )
+    assertIOBoolean(
+      for {
+        keypair <- walletManagementUtils.loadKeys(
+          toplWalletFile,
+          testToplPassword
+        )
+        toplWalletImpl = ToplWalletImpl.make[IO](
+          IO.asyncForIO,
+          walletApi,
+          FellowshipStorageApi.make(walletResource(toplWalletDb)),
+          TemplateStorageApi.make(walletResource(toplWalletDb)),
+          walletStateAlgebra,
+          transactionBuilderApi,
+          genusQueryAlgebra
+        )
+        res <- StartSessionController.startPegoutSession[IO](
+          StartPegoutSessionRequest(
+            testKey,
+            1000,
+            "invalidHash"
+          ),
+          ToplPrivatenet,
+          keypair, // keypair
+          toplWalletImpl, // toplWalletAlgebra
+          sessionManager, // session manager
+          1000
+        )
+      } yield res.isLeft && res.swap.toOption.get == InvalidHash(
+        "Invalid hash invalidHash"
+      )
+    )
+  }
+
+  tmpDirectory.test(
+    "StartSessionController should fail with invalid height (pegout)"
+  ) { _ =>
+    val walletKeyApi = WalletKeyApi.make[IO]()
+    val walletApi = WalletApi.make[IO](walletKeyApi)
+    val walletManagementUtils = new WalletManagementUtils(
+      walletApi,
+      walletKeyApi
+    )
+    val walletStateAlgebra = WalletStateApi
+      .make[IO](walletResource(toplWalletDb), walletApi)
+    val transactionBuilderApi = TransactionBuilderApi.make[IO](
+      ToplPrivatenet.networkId,
+      NetworkConstants.MAIN_LEDGER_ID
+    )
+    val genusQueryAlgebra = GenusQueryAlgebra.make[IO](
+      channelResource(
+        "localhost",
+        9084,
+        false
+      )
+    )
+    val sessionManager = SessionManagerImpl.make[IO](
+      new ConcurrentHashMap[String, SessionInfo]()
+    )
+    assertIOBoolean(
+      for {
+        keypair <- walletManagementUtils.loadKeys(
+          toplWalletFile,
+          testToplPassword
+        )
+        toplWalletImpl = ToplWalletImpl.make[IO](
+          IO.asyncForIO,
+          walletApi,
+          FellowshipStorageApi.make(walletResource(toplWalletDb)),
+          TemplateStorageApi.make(walletResource(toplWalletDb)),
+          walletStateAlgebra,
+          transactionBuilderApi,
+          genusQueryAlgebra
+        )
+        res <- StartSessionController.startPegoutSession[IO](
+          StartPegoutSessionRequest(
+            pegoutTestKey,
+            -1,
+            testHash
+          ),
+          ToplPrivatenet,
+          keypair, // keypair
+          toplWalletImpl, // toplWalletAlgebra
+          sessionManager, // session manager
+          1000
+        )
+      } yield res.isLeft && res.swap.toOption.get == InvalidInput(
+        "Invalid block height -1"
+      )
+    )
+  }
+
 }

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/controllers/StartSessionControllerSpec.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/controllers/StartSessionControllerSpec.scala
@@ -11,6 +11,7 @@ import co.topl.bridge.managers.PeginSessionInfo
 import co.topl.shared.StartPeginSessionRequest
 import co.topl.shared.InvalidKey
 import co.topl.shared.InvalidHash
+import co.topl.bridge.managers.SessionInfo
 
 class StartSessionControllerSpec extends CatsEffectSuite with SharedData {
 
@@ -25,7 +26,7 @@ class StartSessionControllerSpec extends CatsEffectSuite with SharedData {
         peginWallet <- BTCWalletImpl.make[IO](km0)
         currentPubKey <- peginWallet.getCurrentPubKey()
         sessionManager = PeginSessionManagerImpl.make[IO](
-          new ConcurrentHashMap[String, PeginSessionInfo]()
+          new ConcurrentHashMap[String, SessionInfo]()
         )
         res <- StartSessionController.startPeginSession(
           StartPeginSessionRequest(
@@ -38,7 +39,7 @@ class StartSessionControllerSpec extends CatsEffectSuite with SharedData {
           RegTest
         )
         sessionInfo <- sessionManager.getSession(res.toOption.get.sessionID)
-      } yield (sessionInfo.currentWalletIdx == 0)
+      } yield (sessionInfo.asInstanceOf[PeginSessionInfo].currentWalletIdx == 0)
         // (sessionInfo.userPKey == testKey)
         // (sessionInfo.bridgePKey == currentPubKey.hex)
     )
@@ -55,7 +56,7 @@ class StartSessionControllerSpec extends CatsEffectSuite with SharedData {
         peginWallet <- BTCWalletImpl.make[IO](km0)
         currentPubKey <- peginWallet.getCurrentPubKey()
         sessionManager = PeginSessionManagerImpl.make[IO](
-          new ConcurrentHashMap[String, PeginSessionInfo]()
+          new ConcurrentHashMap[String, SessionInfo]()
         )
         res <- StartSessionController.startPeginSession(
           StartPeginSessionRequest(
@@ -84,7 +85,7 @@ class StartSessionControllerSpec extends CatsEffectSuite with SharedData {
         peginWallet <- BTCWalletImpl.make[IO](km0)
         currentPubKey <- peginWallet.getCurrentPubKey()
         sessionManager = PeginSessionManagerImpl.make[IO](
-          new ConcurrentHashMap[String, PeginSessionInfo]()
+          new ConcurrentHashMap[String, SessionInfo]()
         )
         res <- StartSessionController.startPeginSession(
           StartPeginSessionRequest(

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/controllers/StartSessionControllerSpec.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/controllers/StartSessionControllerSpec.scala
@@ -5,10 +5,10 @@ import co.topl.shared.utils.KeyGenerationUtils
 import co.topl.shared.RegTest
 import co.topl.bridge.managers.BTCWalletImpl
 import cats.effect.IO
-import co.topl.bridge.managers.SessionManagerImpl
+import co.topl.bridge.managers.PeginSessionManagerImpl
 import java.util.concurrent.ConcurrentHashMap
-import co.topl.bridge.managers.SessionInfo
-import co.topl.shared.StartSessionRequest
+import co.topl.bridge.managers.PeginSessionInfo
+import co.topl.shared.StartPeginSessionRequest
 import co.topl.shared.InvalidKey
 import co.topl.shared.InvalidHash
 
@@ -24,11 +24,11 @@ class StartSessionControllerSpec extends CatsEffectSuite with SharedData {
         )
         peginWallet <- BTCWalletImpl.make[IO](km0)
         currentPubKey <- peginWallet.getCurrentPubKey()
-        sessionManager = SessionManagerImpl.make[IO](
-          new ConcurrentHashMap[String, SessionInfo]()
+        sessionManager = PeginSessionManagerImpl.make[IO](
+          new ConcurrentHashMap[String, PeginSessionInfo]()
         )
-        res <- StartSessionController.startSession(
-          StartSessionRequest(
+        res <- StartSessionController.startPeginSession(
+          StartPeginSessionRequest(
             testKey,
             testHash
           ),
@@ -38,9 +38,9 @@ class StartSessionControllerSpec extends CatsEffectSuite with SharedData {
           RegTest
         )
         sessionInfo <- sessionManager.getSession(res.toOption.get.sessionID)
-      } yield (sessionInfo.secretHash == testHash) &&
-        (sessionInfo.userPKey == testKey) &&
-        (sessionInfo.bridgePKey == currentPubKey.hex)
+      } yield (sessionInfo.currentWalletIdx == 0)
+        // (sessionInfo.userPKey == testKey)
+        // (sessionInfo.bridgePKey == currentPubKey.hex)
     )
   }
 
@@ -54,11 +54,11 @@ class StartSessionControllerSpec extends CatsEffectSuite with SharedData {
         )
         peginWallet <- BTCWalletImpl.make[IO](km0)
         currentPubKey <- peginWallet.getCurrentPubKey()
-        sessionManager = SessionManagerImpl.make[IO](
-          new ConcurrentHashMap[String, SessionInfo]()
+        sessionManager = PeginSessionManagerImpl.make[IO](
+          new ConcurrentHashMap[String, PeginSessionInfo]()
         )
-        res <- StartSessionController.startSession(
-          StartSessionRequest(
+        res <- StartSessionController.startPeginSession(
+          StartPeginSessionRequest(
             "invalidKey",
             testHash
           ),
@@ -83,11 +83,11 @@ class StartSessionControllerSpec extends CatsEffectSuite with SharedData {
         )
         peginWallet <- BTCWalletImpl.make[IO](km0)
         currentPubKey <- peginWallet.getCurrentPubKey()
-        sessionManager = SessionManagerImpl.make[IO](
-          new ConcurrentHashMap[String, SessionInfo]()
+        sessionManager = PeginSessionManagerImpl.make[IO](
+          new ConcurrentHashMap[String, PeginSessionInfo]()
         )
-        res <- StartSessionController.startSession(
-          StartSessionRequest(
+        res <- StartSessionController.startPeginSession(
+          StartPeginSessionRequest(
             testKey,
             "invalidHash"
           ),

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/managers/SessionManagerSpec.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/managers/SessionManagerSpec.scala
@@ -14,7 +14,7 @@ class SessionManagerSpec extends CatsEffectSuite {
 
   test("SessionManagerAlgebra should create and retrieve a session") {
     val sut =
-      PeginSessionManagerImpl.make[IO](new ConcurrentHashMap[String, PeginSessionInfo]())
+      PeginSessionManagerImpl.make[IO](new ConcurrentHashMap[String, SessionInfo]())
     assertIO(
       for {
         sessionId <- sut.createNewSession(sessionInfo)
@@ -28,7 +28,7 @@ class SessionManagerSpec extends CatsEffectSuite {
 
   test("SessionManagerAlgebra should fail to retrieve a non existing session") {
     val sut =
-      PeginSessionManagerImpl.make[IO](new ConcurrentHashMap[String, PeginSessionInfo]())
+      PeginSessionManagerImpl.make[IO](new ConcurrentHashMap[String, SessionInfo]())
 
     assertIO(
       (for {

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/managers/SessionManagerSpec.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/managers/SessionManagerSpec.scala
@@ -14,7 +14,7 @@ class SessionManagerSpec extends CatsEffectSuite {
 
   test("SessionManagerAlgebra should create and retrieve a session") {
     val sut =
-      PeginSessionManagerImpl.make[IO](new ConcurrentHashMap[String, SessionInfo]())
+      SessionManagerImpl.make[IO](new ConcurrentHashMap[String, SessionInfo]())
     assertIO(
       for {
         sessionId <- sut.createNewSession(sessionInfo)
@@ -28,7 +28,7 @@ class SessionManagerSpec extends CatsEffectSuite {
 
   test("SessionManagerAlgebra should fail to retrieve a non existing session") {
     val sut =
-      PeginSessionManagerImpl.make[IO](new ConcurrentHashMap[String, SessionInfo]())
+      SessionManagerImpl.make[IO](new ConcurrentHashMap[String, SessionInfo]())
 
     assertIO(
       (for {

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/managers/SessionManagerSpec.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/managers/SessionManagerSpec.scala
@@ -7,18 +7,14 @@ import java.util.UUID
 
 class SessionManagerSpec extends CatsEffectSuite {
 
-  val sessionInfo = SessionInfo(
-    "bridgePKey",
+  val sessionInfo = PeginSessionInfo(
     0,
-    "userPKey",
-    "secretHash",
     "scriptAsm",
-    "address"
   )
 
   test("SessionManagerAlgebra should create and retrieve a session") {
     val sut =
-      SessionManagerImpl.make[IO](new ConcurrentHashMap[String, SessionInfo]())
+      PeginSessionManagerImpl.make[IO](new ConcurrentHashMap[String, PeginSessionInfo]())
     assertIO(
       for {
         sessionId <- sut.createNewSession(sessionInfo)
@@ -32,7 +28,7 @@ class SessionManagerSpec extends CatsEffectSuite {
 
   test("SessionManagerAlgebra should fail to retrieve a non existing session") {
     val sut =
-      SessionManagerImpl.make[IO](new ConcurrentHashMap[String, SessionInfo]())
+      PeginSessionManagerImpl.make[IO](new ConcurrentHashMap[String, PeginSessionInfo]())
 
     assertIO(
       (for {

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/managers/WalletManagerSpec.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/managers/WalletManagerSpec.scala
@@ -12,7 +12,7 @@ class WalletManagerSpec extends CatsEffectSuite {
       for {
         km <- KeyGenerationUtils.createKeyManager[IO](
           RegTest,
-          "topl-btc-bridge/src/test/resources/wallet.json",
+          "src/test/resources/wallet.json",
           "password"
         )
         sut <- BTCWalletImpl.make[IO](km)
@@ -28,7 +28,7 @@ class WalletManagerSpec extends CatsEffectSuite {
       for {
         km <- KeyGenerationUtils.createKeyManager[IO](
           RegTest,
-          "topl-btc-bridge/src/test/resources/wallet.json",
+          "src/test/resources/wallet.json",
           "password"
         )
         sut <- BTCWalletImpl.make[IO](km)

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/stubs/BaseToplWalletAlgebra.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/stubs/BaseToplWalletAlgebra.scala
@@ -7,13 +7,21 @@ import co.topl.bridge.managers.ToplWalletAlgebra
 import com.google.protobuf.ByteString
 import io.circe.Json
 import quivr.models.KeyPair
+import co.topl.shared.ToplNetworkIdentifiers
 
 class BaseToplWalletAlgebra extends ToplWalletAlgebra[IO] {
 
-  override def getCurrentPubKeyAndPrepareNext(): IO[(Int, String)] = ???
-
-
   import UnitTestStubs._
+
+  override def setupBridgeWallet(
+      networkId: ToplNetworkIdentifiers,
+      keyPair: KeyPair,
+      userBaseKey: String,
+      sessionId: String,
+      sha256: String,
+      waitTime: Int,
+      currentHeight: Int
+  ): IO[Option[String]] = ???
 
   override def createSimpleAssetMintingTransactionFromParams(
       keyPair: KeyPair,

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/stubs/BaseToplWalletAlgebra.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/stubs/BaseToplWalletAlgebra.scala
@@ -10,6 +10,9 @@ import quivr.models.KeyPair
 
 class BaseToplWalletAlgebra extends ToplWalletAlgebra[IO] {
 
+  override def getCurrentPubKeyAndPrepareNext(): IO[(Int, String)] = ???
+
+
   import UnitTestStubs._
 
   override def createSimpleAssetMintingTransactionFromParams(

--- a/topl-btc-cli/src/main/scala/co/topl/tbcli/Main.scala
+++ b/topl-btc-cli/src/main/scala/co/topl/tbcli/Main.scala
@@ -6,7 +6,7 @@ import cats.effect.IOApp
 import cats.effect.kernel.Sync
 import cats.effect.std
 import co.topl.shared.BitcoinNetworkIdentifiers
-import co.topl.shared.StartSessionRequest
+import co.topl.shared.StartPeginSessionRequest
 import co.topl.shared.utils.KeyGenerationUtils
 import scopt.OParser
 
@@ -42,7 +42,7 @@ object Main extends IOApp with TBCLIParamsDescriptor {
   }
 
   def displayInitSession[F[_]: std.Console](
-      startSessionRequest: StartSessionRequest
+      startSessionRequest: StartPeginSessionRequest
   ): F[Unit] = {
     import cats.implicits._
     import co.topl.tbcli.view.OutputView._
@@ -52,7 +52,7 @@ object Main extends IOApp with TBCLIParamsDescriptor {
   def processInitSession[F[_]: Sync](
       btcNetwork: BitcoinNetworkIdentifiers,
       initSession: InitSession
-  ): F[StartSessionRequest] = {
+  ): F[StartPeginSessionRequest] = {
     import cats.implicits._
     for {
       secretSha256 <- Sync[F].delay(
@@ -70,6 +70,6 @@ object Main extends IOApp with TBCLIParamsDescriptor {
           initSession.password
         )
       pKey <- KeyGenerationUtils.generateKey[F](km, 1)
-    } yield StartSessionRequest(pKey.hex, secretSha256)
+    } yield StartPeginSessionRequest(pKey.hex, secretSha256)
   }
 }

--- a/topl-btc-cli/src/main/scala/co/topl/tbcli/view/OutputView.scala
+++ b/topl-btc-cli/src/main/scala/co/topl/tbcli/view/OutputView.scala
@@ -1,11 +1,11 @@
 package co.topl.tbcli.view
 
 import cats.Show
-import co.topl.shared.StartSessionRequest
+import co.topl.shared.StartPeginSessionRequest
 
 object OutputView {
 
-  implicit val showInitSession: Show[StartSessionRequest] = Show.show { a =>
+  implicit val showInitSession: Show[StartPeginSessionRequest] = Show.show { a =>
     import io.circe.syntax._
     import io.circe.generic.auto._
     a.asJson.spaces2


### PR DESCRIPTION
## Purpose

The goal  of this task is to create  a session for pegout.

## Approach

The current approach is simple but it will probably evolve:

- The user creates a fellowship and a template and exports the VK
- The vk is passed to the bridge with the WS
- The bridge generates a new fellowship and template, and uses the VK that the user passed to initialize an address
- the new address is passed to the user as the escrow address

## Testing

Unit tests have been added.

## Limitations

Currently brambl-cli does not support adding the template with the SHA-256 digest. Thus, this part is only done by the bridge. This will be fixed in the next task.

## Tickets
* TSDK-754
