### PR TITLE
TSDK-812 Sad path BTC reorg.

### DIFF
--- a/.github/workflows/sbt_checkPR.yml
+++ b/.github/workflows/sbt_checkPR.yml
@@ -37,7 +37,7 @@ jobs:
         #
         ports:
            - 9084:9084
-      bitcoin:
+      bitcoin01:
         # Docker Hub image
         image: toplprotocol/bitcoin-zmq:v25-regtest
         #
@@ -45,6 +45,15 @@ jobs:
           - 18444:18444
           - 18443:18443
           - 28332:28332
+        options: --name bitcoin
+      bitcoin02:
+        # Docker Hub image
+        image: toplprotocol/bitcoin-zmq:v25-regtest
+        #
+        ports:
+          - 18446:18444
+          - 18445:18443
+          - 28333:28332
         options: --name bitcoin
     steps:
       - name: Checkout code

--- a/.github/workflows/sbt_checkPR.yml
+++ b/.github/workflows/sbt_checkPR.yml
@@ -45,7 +45,7 @@ jobs:
           - 18444:18444
           - 18443:18443
           - 28332:28332
-        options: --name bitcoin
+        options: --name bitcoin01
       bitcoin02:
         # Docker Hub image
         image: toplprotocol/bitcoin-zmq:v25-regtest
@@ -54,7 +54,7 @@ jobs:
           - 18446:18444
           - 18445:18443
           - 28333:28332
-        options: --name bitcoin
+        options: --name bitcoin02
     steps:
       - name: Checkout code
         uses: actions/checkout@v3.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add new parameter `--btc-confirmation-threshold` to specify the number of confirmations needed for the deposit.
 - Add two new fields to the `StartPeginSessionResponse` message: `minHeight` and `maxHeight`.
 This is needed to know the range of blocks to wait for the redemption.
+- Added parameters `--abtc-group-id` and `--abtc-series-id` to specify the group and series of the asset to mint.
 
 
 ### Changed
@@ -38,6 +39,8 @@ This is needed to know the range of blocks to wait for the redemption.
 - Rename `--blocks-to-recover` to `--btc-blocks-to-recover`.
 - Update the contract for the redemption to include the height. The new contract
 `threshold(1, sha256($sha256) and height($min, $max))`.
+- We now require the asset minted to be present at start time.
+
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ This is needed to know the range of blocks to wait for the redemption.
 - Rename `--blocks-to-recover` to `--btc-blocks-to-recover`.
 - Update the contract for the redemption to include the height. The new contract
 `threshold(1, sha256($sha256) and height($min, $max))`.
-- We now require the asset minted to be present at start time.
+- We now require the group and series tokens to be present at start time.
 
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for sad path: Bridge did not mint the tokens in time.
 - Support for sad path: User did not redeem the tokens in time.
 - Add new parameter `--topl-blocks-to-recover` to specify the number of blocks to wait for the Topl network to recover.
+- Add new parameter `--btc-confirmation-threshold` to specify the number of confirmations needed for the deposit.
 - Add two new fields to the `StartPeginSessionResponse` message: `minHeight` and `maxHeight`.
 This is needed to know the range of blocks to wait for the redemption.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,5 +7,5 @@ RUN mv bitcoin-25.0 /bitcoin
 ENV PATH="${PATH}:/bitcoin/bin"
 RUN mkdir /bitcoin/data
 VOLUME /bitcoin/data
-ENTRYPOINT /bitcoin/bin/bitcoind -datadir=/bitcoin/data -chain=regtest -zmqpubrawblock=tcp://0.0.0.0:28332 -rpcuser=bitcoin -rpcpassword=password -port=18444 -rpcport=18443 -rpcbind=:18443 -rpcallowip=0.0.0.0/0
+ENTRYPOINT ["/bitcoin/bin/bitcoind", "-datadir=/bitcoin/data", "-chain=regtest", "-zmqpubrawblock=tcp://0.0.0.0:28332", "-rpcuser=bitcoin", "-rpcpassword=password", "-port=18444", "-rpcport=18443", "-rpcbind=:18443", "-rpcallowip=0.0.0.0/0"]
 EXPOSE 18443 18444 28332

--- a/integration/setupBridge.sh
+++ b/integration/setupBridge.sh
@@ -15,7 +15,20 @@ export ADDRESS=$(brambl-cli wallet current-address --walletdb $TOPL_WALLET_DB)
 brambl-cli simple-transaction create --from-fellowship nofellowship --from-template genesis --from-interaction 1 --change-fellowship nofellowship --change-template genesis --change-interaction 1  -t $ADDRESS -w $TOPL_WALLET_PASSWORD -o genesisTx.pbuf -n private -a 1000 -h  127.0.0.1 --port 9084 --keyfile $TOPL_WALLET_JSON --walletdb $TOPL_WALLET_DB --fee 10 --transfer-token lvl
 brambl-cli tx prove -i genesisTx.pbuf --walletdb $TOPL_WALLET_DB --keyfile $TOPL_WALLET_JSON -w $TOPL_WALLET_PASSWORD -o genesisTxProved.pbuf
 export GROUP_UTXO=$(brambl-cli tx broadcast -i genesisTxProved.pbuf -h 127.0.0.1 --port 9084)
-# bitcoin-cli -regtest -rpcuser=$BTC_USER -rpcpassword=$BTC_PASSWORD -named createwallet wallet_name=testwallet
-# export ADDRESS=`bitcoin-cli -rpcuser=$BTC_USER -rpcpassword=$BTC_PASSWORD -rpcwallet=testwallet -regtest getnewaddress`
-# echo "ADDRESS: $ADDRESS"
-# bitcoin-cli -rpcuser=$BTC_USER -rpcpassword=$BTC_PASSWORD -regtest generatetoaddress 101 $ADDRESS
+until brambl-cli genus-query utxo-by-address --host localhost --port 9084 --secure false --walletdb $TOPL_WALLET_DB; do sleep 5; done
+echo "label: ToplBTCGroup" > groupPolicy.yaml
+echo "registrationUtxo: $GROUP_UTXO#0" >> groupPolicy.yaml
+brambl-cli simple-minting create --from-fellowship self --from-template default  -h 127.0.0.1 --port 9084 -n private --keyfile $TOPL_WALLET_JSON -w $TOPL_WALLET_PASSWORD -o groupMintingtx.pbuf -i groupPolicy.yaml  --mint-amount 1 --fee 10 --walletdb $TOPL_WALLET_DB --mint-token group
+brambl-cli tx prove -i groupMintingtx.pbuf --walletdb $TOPL_WALLET_DB --keyfile $TOPL_WALLET_JSON -w $TOPL_WALLET_PASSWORD -o groupMintingtxProved.pbuf
+export SERIES_UTXO=$(brambl-cli tx broadcast -i groupMintingtxProved.pbuf -h 127.0.0.1 --port 9084)
+echo "SERIES_UTXO: $SERIES_UTXO"
+until brambl-cli genus-query utxo-by-address --host localhost --port 9084 --secure false --walletdb $TOPL_WALLET_DB; do sleep 5; done
+echo "label: ToplBTCSeries" > seriesPolicy.yaml
+echo "registrationUtxo: $SERIES_UTXO#0" >> seriesPolicy.yaml
+echo "fungibility: group-and-series" >> seriesPolicy.yaml
+echo "quantityDescriptor: liquid" >> seriesPolicy.yaml
+brambl-cli simple-minting create --from-fellowship self --from-template default  -h localhost --port 9084 -n private --keyfile $TOPL_WALLET_JSON -w $TOPL_WALLET_PASSWORD -o seriesMintingTx.pbuf -i seriesPolicy.yaml  --mint-amount 1 --fee 10 --walletdb $TOPL_WALLET_DB --mint-token series
+brambl-cli tx prove -i seriesMintingTx.pbuf --walletdb $TOPL_WALLET_DB --keyfile $TOPL_WALLET_JSON -w $TOPL_WALLET_PASSWORD -o seriesMintingTxProved.pbuf
+export ASSET_UTXO=$(brambl-cli tx broadcast -i seriesMintingTxProved.pbuf -h 127.0.0.1 --port 9084)
+echo "ASSET_UTXO: $ASSET_UTXO"
+until brambl-cli genus-query utxo-by-address --host localhost --port 9084 --secure false --walletdb $TOPL_WALLET_DB; do sleep 5; done

--- a/integration/src/test/resources/logback.xml
+++ b/integration/src/test/resources/logback.xml
@@ -1,0 +1,21 @@
+<configuration debug="false">
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+      <encoder>
+          <pattern>%d{HH:mm:ss.SSS}| %-5level %logger{36} - %msg%n</pattern>
+      </encoder>
+  </appender>
+
+  <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+      <appender-ref ref="STDOUT" />
+  </appender>
+
+  <logger class="io.grpc.netty.shaded.io.grpc.netty.NettyClientHandler" level="WARN" />
+  <logger name="Bifrost.P2P" level="WARN" />
+  <logger name="btc-bridge" level="INFO" />
+  <root level="ERROR">
+      <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
+++ b/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
@@ -123,7 +123,7 @@ class BridgeIntegrationSpec
                       "--btc-url",
                       "http://localhost",
                       "--topl-blocks-to-recover",
-                      "15",
+                      "10",
                       "--abtc-group-id",
                       groupId,
                       "--abtc-series-id",

--- a/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
+++ b/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
@@ -20,7 +20,8 @@ class BridgeIntegrationSpec
     with FailedPeginNoMintModule
     with FailedRedemptionModule
     with FailedPeginNoDepositWithReorgModule
-    with SuccessfulPeginWithClaimReorgModule {
+    with SuccessfulPeginWithClaimReorgModule
+    with SuccessfulPeginWithClaimReorgRetryModule {
 
   val DOCKER_CMD = "docker"
 
@@ -287,6 +288,13 @@ class BridgeIntegrationSpec
     IO.println(
       "Bridge should correctly go back from PeginSessionWaitingForClaimBTCConfirmation"
     ) >> successfulPeginWithClaimError()
+  }
+  cleanupDir.test(
+    "Bridge should correctly retry if claim does not succeed"
+  ) { _ =>
+    IO.println(
+      "Bridge should correctly retry if claim does not succeed"
+    ) >> successfulPeginWithClaimErrorRetry()
   }
 
 }

--- a/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
+++ b/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
@@ -19,7 +19,8 @@ class BridgeIntegrationSpec
     with FailedPeginNoDepositModule
     with FailedPeginNoMintModule
     with FailedRedemptionModule
-    with FailedPeginNoDepositWithReorgModule {
+    with FailedPeginNoDepositWithReorgModule
+    with SuccessfulPeginWithClaimReorgModule {
 
   val DOCKER_CMD = "docker"
 
@@ -190,6 +191,13 @@ class BridgeIntegrationSpec
     IO.println(
       "Bridge should correctly go back from PeginSessionWaitingForEscrowBTCConfirmation"
     ) >> failedPeginNoDepositWithReorg()
+  }
+  cleanupDir.test(
+    "Bridge should correctly go back from PeginSessionWaitingForClaimBTCConfirmation"
+  ) { _ =>
+    IO.println(
+      "Bridge should correctly go back from PeginSessionWaitingForClaimBTCConfirmation"
+    ) >> successfulPeginWithClaimError()
   }
 
 }

--- a/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
+++ b/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
@@ -65,6 +65,21 @@ class BridgeIntegrationSpec
               fiber = f
             }
             .void
+          // network ls
+          networkLs <- process
+            .ProcessBuilder(DOCKER_CMD, networkLs: _*)
+            .spawn[IO]
+            .use { getText }
+          // extract the string that starts with github_network_
+          // the format is
+          // NETWORK ID     NAME      DRIVER    SCOPE
+          // 7b1e3b1b1b1b   github_network_bitcoin01   bridge   local
+          pattern = ".*?(github_network_\\S+)\\s+.*".r
+          networkName = pattern.findFirstMatchIn(networkLs) match {
+            case Some(m) =>
+              m.group(1) // Extract the first group matching the pattern
+            case None => "bridge"
+          }
           // inspect bridge
           bridgeNetwork <- process
             .ProcessBuilder(DOCKER_CMD, inspectBridge: _*)

--- a/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
+++ b/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
@@ -80,9 +80,11 @@ class BridgeIntegrationSpec
               m.group(1) // Extract the first group matching the pattern
             case None => "bridge"
           }
+          // print network name
+          _ <- IO.println("networkName: " + networkName)
           // inspect bridge
           bridgeNetwork <- process
-            .ProcessBuilder(DOCKER_CMD, inspectBridge: _*)
+            .ProcessBuilder(DOCKER_CMD, inspectBridge(networkName): _*)
             .spawn[IO]
             .use { getText }
           // print bridgeNetwork

--- a/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
+++ b/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
@@ -123,7 +123,7 @@ class BridgeIntegrationSpec
                       "--btc-url",
                       "http://localhost",
                       "--topl-blocks-to-recover",
-                      "10",
+                      "15",
                       "--abtc-group-id",
                       groupId,
                       "--abtc-series-id",

--- a/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
+++ b/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
@@ -25,7 +25,6 @@ class BridgeIntegrationSpec
 
   override val munitIOTimeout = Duration(180, "s")
 
-  
   val computeBridgeNetworkName = for {
     // network ls
     networkLs <- process

--- a/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
+++ b/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
@@ -165,23 +165,31 @@ class BridgeIntegrationSpec
   override def munitFixtures = List(startServer)
 
   cleanupDir.test("Bridge should correctly peg-in BTC") { _ =>
-    successfulPegin()
+    IO.println("Bridge should correctly peg-in BTC") >> successfulPegin()
   }
   cleanupDir.test("Bridge should fail correctly when user does not send BTC") {
     _ =>
-      failedPeginNoDeposit()
+      IO.println(
+        "Bridge should fail correctly when user does not send BTC"
+      ) >> failedPeginNoDeposit()
   }
   cleanupDir.test("Bridge should fail correctly when tBTC not minted") { _ =>
-    failedPeginNoMint()
+    IO.println(
+      "Bridge should fail correctly when tBTC not minted"
+    ) >> failedPeginNoMint()
   }
   cleanupDir.test("Bridge should fail correctly when tBTC not redeemed") { _ =>
-    failedRedemption()
+    IO.println(
+      "Bridge should fail correctly when tBTC not redeemed"
+    ) >> failedRedemption()
   }
 
   cleanupDir.test(
     "Bridge should correctly go back from PeginSessionWaitingForEscrowBTCConfirmation"
   ) { _ =>
-    failedPeginNoDepositWithReorg()
+    IO.println(
+      "Bridge should correctly go back from PeginSessionWaitingForEscrowBTCConfirmation"
+    ) >> failedPeginNoDepositWithReorg()
   }
 
 }

--- a/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
+++ b/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
@@ -146,17 +146,61 @@ class BridgeIntegrationSpec
   val cleanupDir = FunFixture[Unit](
     setup = { _ =>
       try {
-        Files.delete(Paths.get(userWalletDb))
-        Files.delete(Paths.get(userWalletMnemonic))
-        Files.delete(Paths.get(userWalletJson))
+        Files.delete(Paths.get(userWalletDb(1)))
+      } catch {
+        case _: Throwable => ()
+      }
+      try {
+        Files.delete(Paths.get(userWalletMnemonic(1)))
+      } catch {
+        case _: Throwable => ()
+      }
+      try {
+        Files.delete(Paths.get(userWalletJson(1)))
+      } catch {
+        case _: Throwable => ()
+      }
+      try {
+        Files.delete(Paths.get(userWalletDb(2)))
+      } catch {
+        case _: Throwable => ()
+      }
+      try {
+        Files.delete(Paths.get(userWalletMnemonic(2)))
+      } catch {
+        case _: Throwable => ()
+      }
+      try {
+        Files.delete(Paths.get(userWalletJson(2)))
+      } catch {
+        case _: Throwable => ()
+      }
+      try {
         Files.delete(Paths.get(vkFile))
+      } catch {
+        case _: Throwable => ()
+      }
+      try {
         Files.delete(Paths.get("fundRedeemTx.pbuf"))
+      } catch {
+        case _: Throwable => ()
+      }
+      try {
         Files.delete(Paths.get("fundRedeemTxProved.pbuf"))
+      } catch {
+        case _: Throwable => ()
+      }
+      try {
         Files.delete(Paths.get("redeemTx.pbuf"))
+      } catch {
+        case _: Throwable => ()
+      }
+      try {
         Files.delete(Paths.get("redeemTxProved.pbuf"))
       } catch {
         case _: Throwable => ()
       }
+
     },
     teardown = { _ =>
       ()

--- a/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
+++ b/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
@@ -124,7 +124,7 @@ class BridgeIntegrationSpec
                       "--btc-url",
                       "http://localhost",
                       "--topl-blocks-to-recover",
-                      "20",
+                      "15",
                       "--abtc-group-id",
                       groupId,
                       "--abtc-series-id",

--- a/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
+++ b/integration/src/test/scala/co/topl/bridge/BridgeIntegrationSpec.scala
@@ -124,7 +124,7 @@ class BridgeIntegrationSpec
                       "--btc-url",
                       "http://localhost",
                       "--topl-blocks-to-recover",
-                      "15",
+                      "20",
                       "--abtc-group-id",
                       groupId,
                       "--abtc-series-id",

--- a/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositModule.scala
@@ -60,7 +60,7 @@ trait FailedPeginNoDepositModule {
         _ <- IO.println("Escrow address: " + startSessionResponse.escrowAddress)
         _ <- IO.println("Generating blocks..")
         _ <- process
-          .ProcessBuilder(DOCKER_CMD, generateToAddress(102, newAddress): _*)
+          .ProcessBuilder(DOCKER_CMD, generateToAddress(1, 102, newAddress): _*)
           .spawn[IO]
           .use(_.exitValue)
         _ <- EmberClientBuilder

--- a/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositModule.scala
@@ -52,7 +52,7 @@ trait FailedPeginNoDepositModule {
                 StartPeginSessionRequest(
                   pkey =
                     "0295bb5a3b80eeccb1e38ab2cbac2545e9af6c7012cdc8d53bd276754c54fc2e4a",
-                  sha256 = sha256ToplSecret
+                  sha256 = shaSecretMap(1)
                 )
               )
             )

--- a/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
@@ -49,7 +49,7 @@ trait FailedPeginNoDepositWithReorgModule {
           .ProcessBuilder(DOCKER_CMD, extractGetTxId: _*)
           .spawn[IO]
           .use(getText)
-        _ <- IO.println("unspent: " + unspent)
+        // _ <- IO.println("unspent: " + unspent)
         txId <- IO.fromEither(
           parse(unspent).map(x => (x \\ "txid").head.asString.get)
         )
@@ -79,8 +79,9 @@ trait FailedPeginNoDepositWithReorgModule {
             )
           })
         _ <- IO.println("Escrow address: " + startSessionResponse.escrowAddress)
+        bridgeNetwork <- computeBridgeNetworkName
         _ <- process
-          .ProcessBuilder(DOCKER_CMD, disconnectBridge(2): _*)
+          .ProcessBuilder(DOCKER_CMD, disconnectBridge(2, bridgeNetwork): _*)
           .spawn[IO]
           .use(getText)
         bitcoinTx <- process
@@ -148,7 +149,7 @@ trait FailedPeginNoDepositWithReorgModule {
           .spawn[IO]
           .use(_.exitValue)
         _ <- process
-          .ProcessBuilder(DOCKER_CMD, connectBridge(2): _*)
+          .ProcessBuilder(DOCKER_CMD, connectBridge(2, bridgeNetwork): _*)
           .spawn[IO]
           .use(getText)
         _ <- EmberClientBuilder

--- a/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
@@ -123,6 +123,17 @@ trait FailedPeginNoDepositWithReorgModule {
             // .ProcessBuilder(DOCKER_CMD, removeNode(2, ipBitcoin01, 18444): _*)
             .spawn[IO]
             .use { getText }
+          // add node
+          _ <- process
+            // .ProcessBuilder(DOCKER_CMD, removeNode(1, ipBitcoin02, 18444): _*)
+            .ProcessBuilder(DOCKER_CMD, forceConnection(1, ipBitcoin02, 18444): _*)
+            .spawn[IO]
+            .use { getText }
+          _ <- process
+            .ProcessBuilder(DOCKER_CMD, forceConnection(2, ipBitcoin01, 18444): _*)
+            // .ProcessBuilder(DOCKER_CMD, removeNode(2, ipBitcoin01, 18444): _*)
+            .spawn[IO]
+            .use { getText }
         bitcoinTx <- process
           .ProcessBuilder(
             DOCKER_CMD,

--- a/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
@@ -52,6 +52,9 @@ trait FailedPeginNoDepositWithReorgModule {
         txId <- IO.fromEither(
           parse(unspent).map(x => (x \\ "txid").head.asString.get)
         )
+        btcAmount <- IO.fromEither(
+          parse(unspent).map(x => (x \\ "amount").head.asString.get)
+        )
         _ <- IO.println("txId: " + txId)
         startSessionResponse <- EmberClientBuilder
           .default[IO]
@@ -123,7 +126,7 @@ trait FailedPeginNoDepositWithReorgModule {
             createTx(
               txId,
               startSessionResponse.escrowAddress,
-              BigDecimal("49.99")
+              BigDecimal(btcAmount) - BigDecimal("0.01")
             ): _*
           )
           .spawn[IO]

--- a/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
@@ -233,6 +233,10 @@ trait FailedPeginNoDepositWithReorgModule {
                 _.mintingStatus == "PeginSessionStateWaitingForBTC"
               )
           })
+        _ <- process
+          .ProcessBuilder(DOCKER_CMD, generateToAddress(1, 8, newAddress): _*)
+          .spawn[IO]
+          .use(_.exitValue)
         _ <- IO.println(
           s"Session ${startSessionResponse.sessionID} went back to wait again"
         )

--- a/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
@@ -80,11 +80,11 @@ trait FailedPeginNoDepositWithReorgModule {
           })
         _ <- IO.println("Escrow address: " + startSessionResponse.escrowAddress)
         bridgeNetwork <- computeBridgeNetworkName
-        dockerDisconnect <- process
-          .ProcessBuilder(DOCKER_CMD, disconnectBridge(2, bridgeNetwork): _*)
-          .spawn[IO]
-          .use(getText)
-        _ <- IO.println("dockerDisconnect: " + dockerDisconnect)
+        // dockerDisconnect <- process
+        //   .ProcessBuilder(DOCKER_CMD, disconnectBridge(2, bridgeNetwork): _*)
+        //   .spawn[IO]
+        //   .use(getText)
+        // _ <- IO.println("dockerDisconnect: " + dockerDisconnect)
         dockerDisconnectError <- process
           .ProcessBuilder(DOCKER_CMD, disconnectBridge(2, bridgeNetwork): _*)
           .spawn[IO]

--- a/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
@@ -73,7 +73,7 @@ trait FailedPeginNoDepositWithReorgModule {
                 StartPeginSessionRequest(
                   pkey =
                     "0295bb5a3b80eeccb1e38ab2cbac2545e9af6c7012cdc8d53bd276754c54fc2e4a",
-                  sha256 = sha256ToplSecret
+                  sha256 = shaSecretMap(1)
                 )
               )
             )

--- a/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
@@ -53,7 +53,7 @@ trait FailedPeginNoDepositWithReorgModule {
           parse(unspent).map(x => (x \\ "txid").head.asString.get)
         )
         btcAmount <- IO.fromEither(
-          parse(unspent).map(x => (x \\ "amount").head.asString.get)
+          parse(unspent).map(x => (x \\ "amount").head.asNumber.get)
         )
         _ <- IO.println("txId: " + txId)
         startSessionResponse <- EmberClientBuilder
@@ -126,7 +126,7 @@ trait FailedPeginNoDepositWithReorgModule {
             createTx(
               txId,
               startSessionResponse.escrowAddress,
-              BigDecimal(btcAmount) - BigDecimal("0.01")
+              btcAmount.toBigDecimal.get - BigDecimal("0.01")
             ): _*
           )
           .spawn[IO]
@@ -193,7 +193,7 @@ trait FailedPeginNoDepositWithReorgModule {
           .ProcessBuilder(DOCKER_CMD, setNetworkActive(1, true): _*)
           .spawn[IO]
           .use { getText }
-          // force connection
+        // force connection
         _ <- process
           .ProcessBuilder(
             DOCKER_CMD,

--- a/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
@@ -114,11 +114,13 @@ trait FailedPeginNoDepositWithReorgModule {
           _ <- IO.println("ipBitcoin01: " + ipBitcoin01)
           // add node
           _ <- process
-            .ProcessBuilder(DOCKER_CMD, removeNode(1, ipBitcoin02, 18444): _*)
+            // .ProcessBuilder(DOCKER_CMD, removeNode(1, ipBitcoin02, 18444): _*)
+            .ProcessBuilder(DOCKER_CMD, setNetworkActive(2, false): _*)
             .spawn[IO]
             .use { getText }
           _ <- process
-            .ProcessBuilder(DOCKER_CMD, removeNode(2, ipBitcoin01, 18444): _*)
+            .ProcessBuilder(DOCKER_CMD, setNetworkActive(1, false): _*)
+            // .ProcessBuilder(DOCKER_CMD, removeNode(2, ipBitcoin01, 18444): _*)
             .spawn[IO]
             .use { getText }
         bitcoinTx <- process
@@ -187,11 +189,13 @@ trait FailedPeginNoDepositWithReorgModule {
           .use(_.exitValue)
           // add node
           _ <- process
-            .ProcessBuilder(DOCKER_CMD, addNode(1, ipBitcoin02, 18444): _*)
+            .ProcessBuilder(DOCKER_CMD, setNetworkActive(2, true): _*)
+            // .ProcessBuilder(DOCKER_CMD, addNode(1, ipBitcoin02, 18444): _*)
             .spawn[IO]
             .use { getText }
           _ <- process
-            .ProcessBuilder(DOCKER_CMD, addNode(2, ipBitcoin01, 18444): _*)
+            .ProcessBuilder(DOCKER_CMD, setNetworkActive(1, true): _*)
+            // .ProcessBuilder(DOCKER_CMD, addNode(2, ipBitcoin01, 18444): _*)
             .spawn[IO]
             .use { getText }
         _ <- EmberClientBuilder

--- a/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
@@ -49,7 +49,6 @@ trait FailedPeginNoDepositWithReorgModule {
           .ProcessBuilder(DOCKER_CMD, extractGetTxId: _*)
           .spawn[IO]
           .use(getText)
-        // _ <- IO.println("unspent: " + unspent)
         txId <- IO.fromEither(
           parse(unspent).map(x => (x \\ "txid").head.asString.get)
         )
@@ -141,7 +140,7 @@ trait FailedPeginNoDepositWithReorgModule {
         sentTxId <- process
           .ProcessBuilder(DOCKER_CMD, sendTransaction(signedTxHex): _*)
           .spawn[IO]
-          .use(getText)
+          .use(getError)
         _ <- IO.println("sentTxId: " + sentTxId)
         _ <- process
           .ProcessBuilder(DOCKER_CMD, generateToAddress(1, 2, newAddress): _*)

--- a/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
@@ -112,26 +112,20 @@ trait FailedPeginNoDepositWithReorgModule {
           )
           // print IP BTC 01
           _ <- IO.println("ipBitcoin01: " + ipBitcoin01)
-          // add node
           _ <- process
-            // .ProcessBuilder(DOCKER_CMD, removeNode(1, ipBitcoin02, 18444): _*)
             .ProcessBuilder(DOCKER_CMD, setNetworkActive(2, false): _*)
             .spawn[IO]
             .use { getText }
           _ <- process
             .ProcessBuilder(DOCKER_CMD, setNetworkActive(1, false): _*)
-            // .ProcessBuilder(DOCKER_CMD, removeNode(2, ipBitcoin01, 18444): _*)
             .spawn[IO]
             .use { getText }
-          // add node
           _ <- process
-            // .ProcessBuilder(DOCKER_CMD, removeNode(1, ipBitcoin02, 18444): _*)
             .ProcessBuilder(DOCKER_CMD, forceConnection(1, ipBitcoin02, 18444): _*)
             .spawn[IO]
             .use { getText }
           _ <- process
             .ProcessBuilder(DOCKER_CMD, forceConnection(2, ipBitcoin01, 18444): _*)
-            // .ProcessBuilder(DOCKER_CMD, removeNode(2, ipBitcoin01, 18444): _*)
             .spawn[IO]
             .use { getText }
         bitcoinTx <- process

--- a/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
@@ -80,10 +80,16 @@ trait FailedPeginNoDepositWithReorgModule {
           })
         _ <- IO.println("Escrow address: " + startSessionResponse.escrowAddress)
         bridgeNetwork <- computeBridgeNetworkName
-        _ <- process
+        dockerDisconnect <- process
           .ProcessBuilder(DOCKER_CMD, disconnectBridge(2, bridgeNetwork): _*)
           .spawn[IO]
           .use(getText)
+        _ <- IO.println("dockerDisconnect: " + dockerDisconnect)
+        dockerDisconnectError <- process
+          .ProcessBuilder(DOCKER_CMD, disconnectBridge(2, bridgeNetwork): _*)
+          .spawn[IO]
+          .use(getError)
+        _ <- IO.println("dockerDisconnectError: " + dockerDisconnectError)
         bitcoinTx <- process
           .ProcessBuilder(
             DOCKER_CMD,

--- a/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedPeginNoDepositWithReorgModule.scala
@@ -182,7 +182,7 @@ trait FailedPeginNoDepositWithReorgModule {
           .ProcessBuilder(DOCKER_CMD, generateToAddress(2, 8, newAddress): _*)
           .spawn[IO]
           .use(_.exitValue)
-        // add node
+        // reconnect network
         _ <- process
           .ProcessBuilder(DOCKER_CMD, setNetworkActive(2, true): _*)
           .spawn[IO]

--- a/integration/src/test/scala/co/topl/bridge/FailedPeginNoMint.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedPeginNoMint.scala
@@ -79,7 +79,7 @@ trait FailedPeginNoMintModule {
         bitcoinTx <- process
           .ProcessBuilder(
             DOCKER_CMD,
-            createTx(txId, startSessionResponse.escrowAddress, BigDecimal("12.49")): _*
+            createTx(txId, startSessionResponse.escrowAddress, BigDecimal("24.99")): _*
           )
           .spawn[IO]
           .use(getText)

--- a/integration/src/test/scala/co/topl/bridge/FailedPeginNoMint.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedPeginNoMint.scala
@@ -98,7 +98,7 @@ trait FailedPeginNoMintModule {
         _ <- IO.println("Generating blocks..")
         _ <- IO.println("sentTxId: " + sentTxId)
         _ <- process
-          .ProcessBuilder(DOCKER_CMD, generateToAddress(102, newAddress): _*)
+          .ProcessBuilder(DOCKER_CMD, generateToAddress(1, 102, newAddress): _*)
           .spawn[IO]
           .use(_.exitValue)
         _ <- EmberClientBuilder

--- a/integration/src/test/scala/co/topl/bridge/FailedPeginNoMint.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedPeginNoMint.scala
@@ -45,7 +45,7 @@ trait FailedPeginNoMintModule {
           .ProcessBuilder(DOCKER_CMD, extractGetTxId: _*)
           .spawn[IO]
           .use(getText)
-        _ <- IO.println("unspent: " + unspent)
+        // _ <- IO.println("unspent: " + unspent)
         txId <- IO.fromEither(
           parse(unspent).map(x => (x \\ "txid").head.asString.get)
         )

--- a/integration/src/test/scala/co/topl/bridge/FailedPeginNoMint.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedPeginNoMint.scala
@@ -79,7 +79,7 @@ trait FailedPeginNoMintModule {
         bitcoinTx <- process
           .ProcessBuilder(
             DOCKER_CMD,
-            createTx(txId, startSessionResponse.escrowAddress, BigDecimal("49.99")): _*
+            createTx(txId, startSessionResponse.escrowAddress, BigDecimal("24.99")): _*
           )
           .spawn[IO]
           .use(getText)

--- a/integration/src/test/scala/co/topl/bridge/FailedPeginNoMint.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedPeginNoMint.scala
@@ -49,6 +49,9 @@ trait FailedPeginNoMintModule {
         txId <- IO.fromEither(
           parse(unspent).map(x => (x \\ "txid").head.asString.get)
         )
+        btcAmount <- IO.fromEither(
+          parse(unspent).map(x => (x \\ "amount").head.asNumber.get)
+        )
         _ <- IO.println("txId: " + txId)
         startSessionResponse <- EmberClientBuilder
           .default[IO]
@@ -79,7 +82,8 @@ trait FailedPeginNoMintModule {
         bitcoinTx <- process
           .ProcessBuilder(
             DOCKER_CMD,
-            createTx(txId, startSessionResponse.escrowAddress, BigDecimal("24.99")): _*
+            createTx(txId, startSessionResponse.escrowAddress, 
+              btcAmount.toBigDecimal.get - BigDecimal("0.01")): _*
           )
           .spawn[IO]
           .use(getText)

--- a/integration/src/test/scala/co/topl/bridge/FailedPeginNoMint.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedPeginNoMint.scala
@@ -79,7 +79,7 @@ trait FailedPeginNoMintModule {
         bitcoinTx <- process
           .ProcessBuilder(
             DOCKER_CMD,
-            createTx(txId, startSessionResponse.escrowAddress, BigDecimal("24.99")): _*
+            createTx(txId, startSessionResponse.escrowAddress, BigDecimal("49.99")): _*
           )
           .spawn[IO]
           .use(getText)

--- a/integration/src/test/scala/co/topl/bridge/FailedPeginNoMint.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedPeginNoMint.scala
@@ -69,7 +69,7 @@ trait FailedPeginNoMintModule {
                 StartPeginSessionRequest(
                   pkey =
                     "0295bb5a3b80eeccb1e38ab2cbac2545e9af6c7012cdc8d53bd276754c54fc2e4a",
-                  sha256 = sha256ToplSecret
+                  sha256 = shaSecretMap(1)
                 )
               )
             )

--- a/integration/src/test/scala/co/topl/bridge/FailedRedemptionModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedRedemptionModule.scala
@@ -74,7 +74,7 @@ trait FailedRedemptionModule {
                 StartPeginSessionRequest(
                   pkey =
                     "0295bb5a3b80eeccb1e38ab2cbac2545e9af6c7012cdc8d53bd276754c54fc2e4a",
-                  sha256 = sha256ToplSecret
+                  sha256 = shaSecretMap(1)
                 )
               )
             )

--- a/integration/src/test/scala/co/topl/bridge/FailedRedemptionModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedRedemptionModule.scala
@@ -56,7 +56,7 @@ trait FailedRedemptionModule {
           .ProcessBuilder(DOCKER_CMD, extractGetTxId: _*)
           .spawn[IO]
           .use(getText)
-        _ <- IO.println("unspent: " + unspent)
+        // _ <- IO.println("unspent: " + unspent)
         txId <- IO.fromEither(
           parse(unspent).map(x => (x \\ "txid").head.asString.get)
         )

--- a/integration/src/test/scala/co/topl/bridge/FailedRedemptionModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedRedemptionModule.scala
@@ -119,7 +119,7 @@ trait FailedRedemptionModule {
         _ <- IO.println("Generating blocks..")
         _ <- IO.println("sentTxId: " + sentTxId)
         _ <- process
-          .ProcessBuilder(DOCKER_CMD, generateToAddress(6, newAddress): _*)
+          .ProcessBuilder(DOCKER_CMD, generateToAddress(7, newAddress): _*)
           .spawn[IO]
           .use(_.exitValue)
         _ <- EmberClientBuilder

--- a/integration/src/test/scala/co/topl/bridge/FailedRedemptionModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedRedemptionModule.scala
@@ -49,7 +49,7 @@ trait FailedRedemptionModule {
           .use(getText)
         _ <- IO.println("newAddress: " + newAddress)
         _ <- process
-          .ProcessBuilder(DOCKER_CMD, generateToAddress(1, 101, newAddress): _*)
+          .ProcessBuilder(DOCKER_CMD, generateToAddress(1, 1, newAddress): _*)
           .spawn[IO]
           .use(_.exitValue)
         unspent <- process

--- a/integration/src/test/scala/co/topl/bridge/FailedRedemptionModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedRedemptionModule.scala
@@ -32,12 +32,6 @@ trait FailedRedemptionModule {
           .spawn[IO]
           .use { getText }
         _ <- IO.println("cwd: " + cwd)
-        initResult <- initUserWallet.use { getText }
-        _ <- IO.println("initResult: " + initResult)
-        addFellowshipResult <- addFellowship.use { getText }
-        _ <- IO.println("addFellowshipResult: " + addFellowshipResult)
-        addSecretResult <- addSecret.use { getText }
-        _ <- IO.println("addSecretResult: " + addSecretResult)
         createWalletOut <- process
           .ProcessBuilder(DOCKER_CMD, createWallet: _*)
           .spawn[IO]
@@ -86,12 +80,6 @@ trait FailedRedemptionModule {
             )
           })
         _ <- IO.println("Escrow address: " + startSessionResponse.escrowAddress)
-        addTemplateResult <- addTemplate(
-          sha256ToplSecret,
-          startSessionResponse.minHeight,
-          startSessionResponse.maxHeight
-        ).use { getText }
-        _ <- IO.println("addTemplateResult: " + addTemplateResult)
         _ <- IO(Source.fromString(startSessionResponse.descriptor))
         bitcoinTx <- process
           .ProcessBuilder(

--- a/integration/src/test/scala/co/topl/bridge/FailedRedemptionModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedRedemptionModule.scala
@@ -55,6 +55,9 @@ trait FailedRedemptionModule {
           parse(unspent).map(x => (x \\ "txid").head.asString.get)
         )
         _ <- IO.println("txId: " + txId)
+        btcAmount <- IO.fromEither(
+          parse(unspent).map(x => (x \\ "amount").head.asNumber.get)
+        )
         startSessionResponse <- EmberClientBuilder
           .default[IO]
           .build
@@ -87,7 +90,7 @@ trait FailedRedemptionModule {
             createTx(
               txId,
               startSessionResponse.escrowAddress,
-              BigDecimal("49.99")
+              btcAmount.toBigDecimal.get - BigDecimal("0.01")
             ): _*
           )
           .spawn[IO]

--- a/integration/src/test/scala/co/topl/bridge/FailedRedemptionModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/FailedRedemptionModule.scala
@@ -49,7 +49,7 @@ trait FailedRedemptionModule {
           .use(getText)
         _ <- IO.println("newAddress: " + newAddress)
         _ <- process
-          .ProcessBuilder(DOCKER_CMD, generateToAddress(1, 1, newAddress): _*)
+          .ProcessBuilder(DOCKER_CMD, generateToAddress(1, 101, newAddress): _*)
           .spawn[IO]
           .use(_.exitValue)
         unspent <- process
@@ -115,7 +115,7 @@ trait FailedRedemptionModule {
         sentTxId <- process
           .ProcessBuilder(DOCKER_CMD, sendTransaction(signedTxHex): _*)
           .spawn[IO]
-          .use(getText)
+          .use(getError)
         _ <- IO.println("Generating blocks..")
         _ <- IO.println("sentTxId: " + sentTxId)
         _ <- process

--- a/integration/src/test/scala/co/topl/bridge/SuccessfulPeginModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/SuccessfulPeginModule.scala
@@ -34,11 +34,11 @@ trait SuccessfulPeginModule {
           .spawn[IO]
           .use { getText }
         _ <- IO.println("cwd: " + cwd)
-        initResult <- initUserWallet.use { getText }
+        initResult <- initUserWallet(1).use { getText }
         _ <- IO.println("initResult: " + initResult)
-        addFellowshipResult <- addFellowship.use { getText }
+        addFellowshipResult <- addFellowship(1).use { getText }
         _ <- IO.println("addFellowshipResult: " + addFellowshipResult)
-        addSecretResult <- addSecret.use { getText }
+        addSecretResult <- addSecret(1).use { getText }
         _ <- IO.println("addSecretResult: " + addSecretResult)
         createWalletOut <- process
           .ProcessBuilder(DOCKER_CMD, createWallet: _*)
@@ -90,6 +90,7 @@ trait SuccessfulPeginModule {
         _ <- IO.println("script: " + startSessionResponse.script)
         _ <- IO.println("Escrow address: " + startSessionResponse.escrowAddress)
         addTemplateResult <- addTemplate(
+          1,
           sha256ToplSecret,
           startSessionResponse.minHeight,
           startSessionResponse.maxHeight
@@ -164,13 +165,14 @@ trait SuccessfulPeginModule {
           .through(Files[IO].writeAll(fs2.io.file.Path(vkFile)))
           .compile
           .drain
-        importVkResult <- importVks.use { getText }
+        importVkResult <- importVks(1).use { getError }
         _ <- IO.println("importVkResult: " + importVkResult)
-        fundRedeemAddressTx <- fundRedeemAddressTx(
+        fundRedeemAddressTx <- fundRedeemAddressTx(1, 
           mintingStatusResponse.address
-        ).use { getText }
+        ).use { getError }
         _ <- IO.println("fundRedeemAddressTx: " + fundRedeemAddressTx)
         proveFundRedeemAddressTxRes <- proveFundRedeemAddressTx(
+          1,
           "fundRedeemTx.pbuf",
           "fundRedeemTxProved.pbuf"
         ).use { getText }
@@ -185,7 +187,7 @@ trait SuccessfulPeginModule {
         _ <- IO.println(
           "broadcastFundRedeemAddressTxRes: " + broadcastFundRedeemAddressTxRes
         )
-        utxo <- getCurrentUtxosFromAddress(mintingStatusResponse.address)
+        utxo <- getCurrentUtxosFromAddress(1, mintingStatusResponse.address)
           .use(
             getText
           )
@@ -207,8 +209,9 @@ trait SuccessfulPeginModule {
           .trim()
         _ <- IO.println("groupId: " + groupId)
         _ <- IO.println("seriesId: " + seriesId)
-        currentAddress <- currentAddress.use { getText }
+        currentAddress <- currentAddress(1).use { getText }
         redeemAddressTx <- redeemAddressTx(
+          1,
           currentAddress,
           4999000000L,
           groupId,
@@ -216,6 +219,7 @@ trait SuccessfulPeginModule {
         ).use { getText }
         _ <- IO.println("redeemAddressTx: " + redeemAddressTx)
         proveFundRedeemAddressTxRes <- proveFundRedeemAddressTx(
+          1,
           "redeemTx.pbuf",
           "redeemTxProved.pbuf"
         )
@@ -228,7 +232,7 @@ trait SuccessfulPeginModule {
         _ <- broadcastFundRedeemAddressTx("redeemTxProved.pbuf").use {
           getText
         }
-        utxo <- getCurrentUtxosFromAddress(currentAddress)
+        utxo <- getCurrentUtxosFromAddress(1, currentAddress)
           .use(
             getText
           )

--- a/integration/src/test/scala/co/topl/bridge/SuccessfulPeginModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/SuccessfulPeginModule.scala
@@ -82,7 +82,7 @@ trait SuccessfulPeginModule {
                 StartPeginSessionRequest(
                   pkey =
                     "0295bb5a3b80eeccb1e38ab2cbac2545e9af6c7012cdc8d53bd276754c54fc2e4a",
-                  sha256 = sha256ToplSecret
+                  sha256 = shaSecretMap(1)
                 )
               )
             )
@@ -91,7 +91,7 @@ trait SuccessfulPeginModule {
         _ <- IO.println("Escrow address: " + startSessionResponse.escrowAddress)
         addTemplateResult <- addTemplate(
           1,
-          sha256ToplSecret,
+          shaSecretMap(1),
           startSessionResponse.minHeight,
           startSessionResponse.maxHeight
         ).use { getText }

--- a/integration/src/test/scala/co/topl/bridge/SuccessfulPeginModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/SuccessfulPeginModule.scala
@@ -51,7 +51,7 @@ trait SuccessfulPeginModule {
           .use(getText)
         _ <- IO.println("newAddress: " + newAddress)
         _ <- process
-          .ProcessBuilder(DOCKER_CMD, generateToAddress(101, newAddress): _*)
+          .ProcessBuilder(DOCKER_CMD, generateToAddress(1, 101, newAddress): _*)
           .spawn[IO]
           .use(_.exitValue)
         unspent <- process
@@ -122,7 +122,7 @@ trait SuccessfulPeginModule {
         _ <- IO.println("Generating blocks..")
         _ <- IO.println("sentTxId: " + sentTxId)
         _ <- process
-          .ProcessBuilder(DOCKER_CMD, generateToAddress(7, newAddress): _*)
+          .ProcessBuilder(DOCKER_CMD, generateToAddress(1, 8, newAddress): _*)
           .spawn[IO]
           .use(_.exitValue)
         mintingStatusResponse <- EmberClientBuilder
@@ -236,7 +236,7 @@ trait SuccessfulPeginModule {
         _ <- IO.println("utxos: " + utxo)
         _ <- IO.sleep(5.second)
         _ <- process
-          .ProcessBuilder(DOCKER_CMD, generateToAddress(6, newAddress): _*)
+          .ProcessBuilder(DOCKER_CMD, generateToAddress(1, 8, newAddress): _*)
           .spawn[IO]
           .use(_.exitValue)
         _ <- EmberClientBuilder
@@ -263,7 +263,7 @@ trait SuccessfulPeginModule {
                 IO.println(x.code) >> process
                   .ProcessBuilder(
                     DOCKER_CMD,
-                    generateToAddress(1, newAddress): _*
+                    generateToAddress(1, 1, newAddress): _*
                   )
                   .spawn[IO]
                   .use(_.exitValue) >> IO.sleep(5.second) >> IO.pure(x)

--- a/integration/src/test/scala/co/topl/bridge/SuccessfulPeginModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/SuccessfulPeginModule.scala
@@ -58,7 +58,7 @@ trait SuccessfulPeginModule {
           .ProcessBuilder(DOCKER_CMD, extractGetTxId: _*)
           .spawn[IO]
           .use(getText)
-        _ <- IO.println("unspent: " + unspent)
+        // _ <- IO.println("unspent: " + unspent)
         txId <- IO.fromEither(
           parse(unspent).map(x => (x \\ "txid").head.asString.get)
         )

--- a/integration/src/test/scala/co/topl/bridge/SuccessfulPeginModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/SuccessfulPeginModule.scala
@@ -122,7 +122,7 @@ trait SuccessfulPeginModule {
         _ <- IO.println("Generating blocks..")
         _ <- IO.println("sentTxId: " + sentTxId)
         _ <- process
-          .ProcessBuilder(DOCKER_CMD, generateToAddress(6, newAddress): _*)
+          .ProcessBuilder(DOCKER_CMD, generateToAddress(7, newAddress): _*)
           .spawn[IO]
           .use(_.exitValue)
         mintingStatusResponse <- EmberClientBuilder

--- a/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgModule.scala
@@ -133,7 +133,7 @@ trait SuccessfulPeginWithClaimReorgModule {
             createTx(
               txId,
               startSessionResponse.escrowAddress,
-              BigDecimal("24.99")
+              BigDecimal("49.99")
             ): _*
           )
           .spawn[IO]
@@ -244,7 +244,7 @@ trait SuccessfulPeginWithClaimReorgModule {
         redeemAddressTx <- redeemAddressTx(
           2,
           currentAddress,
-          2499000000L,
+          4999000000L,
           groupId,
           seriesId
         ).use { getText }

--- a/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgModule.scala
@@ -96,7 +96,7 @@ trait SuccessfulPeginWithClaimReorgModule {
           parse(unspent).map(x => (x \\ "txid").head.asString.get)
         )
         btcAmount <- IO.fromEither(
-          parse(unspent).map(x => (x \\ "amount").head.asString.get)
+          parse(unspent).map(x => (x \\ "amount").head.asNumber.get)
         )
         _ <- IO.println("txId: " + txId)
         startSessionResponse <- EmberClientBuilder
@@ -139,7 +139,7 @@ trait SuccessfulPeginWithClaimReorgModule {
             createTx(
               txId,
               startSessionResponse.escrowAddress,
-              BigDecimal(btcAmount) - BigDecimal("0.01")
+              btcAmount.toBigDecimal.get - BigDecimal("0.01")
             ): _*
           )
           .spawn[IO]
@@ -253,10 +253,11 @@ trait SuccessfulPeginWithClaimReorgModule {
         _ <- IO.println("groupId: " + groupId)
         _ <- IO.println("seriesId: " + seriesId)
         currentAddress <- currentAddress(2).use { getText }
+        _ <- IO.println("btcAmount.toString: " + btcAmount.toString)
         redeemAddressTx <- redeemAddressTx(
           2,
           currentAddress,
-          BigDecimal(btcAmount + "99000000").toLong,
+          BigDecimal(btcAmount.toString + "99000000").toLong,
           groupId,
           seriesId
         ).use { getText }

--- a/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgModule.scala
@@ -133,7 +133,7 @@ trait SuccessfulPeginWithClaimReorgModule {
             createTx(
               txId,
               startSessionResponse.escrowAddress,
-              BigDecimal("49.99")
+              BigDecimal("24.99")
             ): _*
           )
           .spawn[IO]
@@ -244,7 +244,7 @@ trait SuccessfulPeginWithClaimReorgModule {
         redeemAddressTx <- redeemAddressTx(
           2,
           currentAddress,
-          4999000000L,
+          2499000000L,
           groupId,
           seriesId
         ).use { getText }

--- a/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgModule.scala
@@ -256,7 +256,7 @@ trait SuccessfulPeginWithClaimReorgModule {
         redeemAddressTx <- redeemAddressTx(
           2,
           currentAddress,
-          4999000000L,
+          BigDecimal(btcAmount + "99000000").toLong,
           groupId,
           seriesId
         ).use { getText }

--- a/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgModule.scala
@@ -64,11 +64,11 @@ trait SuccessfulPeginWithClaimReorgModule {
           .spawn[IO]
           .use { getText }
         _ <- IO.println("cwd: " + cwd)
-        initResult <- initUserWallet.use { getText }
+        initResult <- initUserWallet(2).use { getText }
         _ <- IO.println("initResult: " + initResult)
-        addFellowshipResult <- addFellowship.use { getText }
+        addFellowshipResult <- addFellowship(2).use { getText }
         _ <- IO.println("addFellowshipResult: " + addFellowshipResult)
-        addSecretResult <- addSecret.use { getText }
+        addSecretResult <- addSecret(2).use { getText }
         _ <- IO.println("addSecretResult: " + addSecretResult)
         createWalletOut <- process
           .ProcessBuilder(DOCKER_CMD, createWallet: _*)
@@ -120,6 +120,7 @@ trait SuccessfulPeginWithClaimReorgModule {
         _ <- IO.println("script: " + startSessionResponse.script)
         _ <- IO.println("Escrow address: " + startSessionResponse.escrowAddress)
         addTemplateResult <- addTemplate(
+          2,
           sha256ToplSecret,
           startSessionResponse.minHeight,
           startSessionResponse.maxHeight
@@ -148,7 +149,7 @@ trait SuccessfulPeginWithClaimReorgModule {
         sentTxId <- process
           .ProcessBuilder(DOCKER_CMD, sendTransaction(signedTxHex): _*)
           .spawn[IO]
-          .use(getText)
+          .use(getError)
         _ <- IO.println("Generating blocks..")
         _ <- IO.println("sentTxId: " + sentTxId)
         _ <- process
@@ -194,13 +195,15 @@ trait SuccessfulPeginWithClaimReorgModule {
           .through(Files[IO].writeAll(fs2.io.file.Path(vkFile)))
           .compile
           .drain
-        importVkResult <- importVks.use { getText }
+        importVkResult <- importVks(2).use { getText }
         _ <- IO.println("importVkResult: " + importVkResult)
         fundRedeemAddressTx <- fundRedeemAddressTx(
+          2,
           mintingStatusResponse.address
         ).use { getText }
         _ <- IO.println("fundRedeemAddressTx: " + fundRedeemAddressTx)
         proveFundRedeemAddressTxRes <- proveFundRedeemAddressTx(
+          2,
           "fundRedeemTx.pbuf",
           "fundRedeemTxProved.pbuf"
         ).use { getText }
@@ -215,7 +218,7 @@ trait SuccessfulPeginWithClaimReorgModule {
         _ <- IO.println(
           "broadcastFundRedeemAddressTxRes: " + broadcastFundRedeemAddressTxRes
         )
-        utxo <- getCurrentUtxosFromAddress(mintingStatusResponse.address)
+        utxo <- getCurrentUtxosFromAddress(2, mintingStatusResponse.address)
           .use(
             getText
           )
@@ -237,8 +240,9 @@ trait SuccessfulPeginWithClaimReorgModule {
           .trim()
         _ <- IO.println("groupId: " + groupId)
         _ <- IO.println("seriesId: " + seriesId)
-        currentAddress <- currentAddress.use { getText }
+        currentAddress <- currentAddress(2).use { getText }
         redeemAddressTx <- redeemAddressTx(
+          2,
           currentAddress,
           4999000000L,
           groupId,
@@ -246,6 +250,7 @@ trait SuccessfulPeginWithClaimReorgModule {
         ).use { getText }
         _ <- IO.println("redeemAddressTx: " + redeemAddressTx)
         proveFundRedeemAddressTxRes <- proveFundRedeemAddressTx(
+          2,
           "redeemTx.pbuf",
           "redeemTxProved.pbuf"
         )
@@ -268,7 +273,7 @@ trait SuccessfulPeginWithClaimReorgModule {
         _ <- broadcastFundRedeemAddressTx("redeemTxProved.pbuf").use {
           getText
         }
-        utxo <- getCurrentUtxosFromAddress(currentAddress)
+        utxo <- getCurrentUtxosFromAddress(2, currentAddress)
           .use(
             getText
           )

--- a/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgModule.scala
@@ -88,7 +88,6 @@ trait SuccessfulPeginWithClaimReorgModule {
           .ProcessBuilder(DOCKER_CMD, extractGetTxId: _*)
           .spawn[IO]
           .use(getText)
-        // _ <- IO.println("unspent: " + unspent)
         txId <- IO.fromEither(
           parse(unspent).map(x => (x \\ "txid").head.asString.get)
         )
@@ -112,7 +111,7 @@ trait SuccessfulPeginWithClaimReorgModule {
                 StartPeginSessionRequest(
                   pkey =
                     "0295bb5a3b80eeccb1e38ab2cbac2545e9af6c7012cdc8d53bd276754c54fc2e4a",
-                  sha256 = sha256ToplSecret01
+                  sha256 = shaSecretMap(2)
                 )
               )
             )
@@ -121,7 +120,7 @@ trait SuccessfulPeginWithClaimReorgModule {
         _ <- IO.println("Escrow address: " + startSessionResponse.escrowAddress)
         addTemplateResult <- addTemplate(
           2,
-          sha256ToplSecret01,
+          shaSecretMap(2),
           startSessionResponse.minHeight,
           startSessionResponse.maxHeight
         ).use { getText }

--- a/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgModule.scala
@@ -112,7 +112,7 @@ trait SuccessfulPeginWithClaimReorgModule {
                 StartPeginSessionRequest(
                   pkey =
                     "0295bb5a3b80eeccb1e38ab2cbac2545e9af6c7012cdc8d53bd276754c54fc2e4a",
-                  sha256 = sha256ToplSecret
+                  sha256 = sha256ToplSecret01
                 )
               )
             )
@@ -121,7 +121,7 @@ trait SuccessfulPeginWithClaimReorgModule {
         _ <- IO.println("Escrow address: " + startSessionResponse.escrowAddress)
         addTemplateResult <- addTemplate(
           2,
-          sha256ToplSecret,
+          sha256ToplSecret01,
           startSessionResponse.minHeight,
           startSessionResponse.maxHeight
         ).use { getText }

--- a/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgModule.scala
@@ -1,0 +1,375 @@
+package co.topl.bridge
+import cats.effect.IO
+import co.topl.shared.BridgeContants
+import co.topl.shared.MintingStatusRequest
+import co.topl.shared.MintingStatusResponse
+import co.topl.shared.StartPeginSessionRequest
+import co.topl.shared.StartPeginSessionResponse
+import fs2.io.file.Files
+import fs2.io.process
+import io.circe.parser._
+import org.http4s.Method
+import org.http4s.Request
+import org.http4s.Uri
+import org.http4s._
+import org.http4s.ember.client._
+import org.http4s.headers.`Content-Type`
+
+import java.io.ByteArrayInputStream
+import scala.concurrent.duration._
+import scala.io.Source
+
+trait SuccessfulPeginWithClaimReorgModule {
+
+  // self BridgeIntegrationSpec
+  self: BridgeIntegrationSpec =>
+
+  def successfulPeginWithClaimError(): IO[Unit] = {
+    import co.topl.bridge.implicits._
+
+    assertIO(
+      for {
+        bridgeNetwork <- computeBridgeNetworkName
+        ipBitcoin02 <- IO.fromEither(
+          parse(bridgeNetwork)
+            .map(x =>
+              (((x.asArray.get.head \\ "Containers").head.asObject.map { x =>
+                x.filter(x => (x._2 \\ "Name").head.asString.get == "bitcoin02")
+                  .values
+                  .head
+              }).get \\ "IPv4Address").head.asString.get
+                .split("/")
+                .head
+            )
+        )
+        // print IP BTC 02
+        _ <- IO.println("ipBitcoin02: " + ipBitcoin02)
+        // parse
+        ipBitcoin01 <- IO.fromEither(
+          parse(bridgeNetwork)
+            .map(x =>
+              (((x.asArray.get.head \\ "Containers").head.asObject.map { x =>
+                x.filter(x => (x._2 \\ "Name").head.asString.get == "bitcoin01")
+                  .values
+                  .head
+              }).get \\ "IPv4Address").head.asString.get
+                .split("/")
+                .head
+            )
+        )
+        // print IP BTC 01
+        _ <- IO.println("ipBitcoin01: " + ipBitcoin01)
+        cwd <- process
+          .ProcessBuilder("pwd")
+          .spawn[IO]
+          .use { getText }
+        _ <- IO.println("cwd: " + cwd)
+        initResult <- initUserWallet.use { getText }
+        _ <- IO.println("initResult: " + initResult)
+        addFellowshipResult <- addFellowship.use { getText }
+        _ <- IO.println("addFellowshipResult: " + addFellowshipResult)
+        addSecretResult <- addSecret.use { getText }
+        _ <- IO.println("addSecretResult: " + addSecretResult)
+        createWalletOut <- process
+          .ProcessBuilder(DOCKER_CMD, createWallet: _*)
+          .spawn[IO]
+          .use { getText }
+        _ <- IO.println("createWalletOut: " + createWalletOut)
+        newAddress <- process // we get the new address
+          .ProcessBuilder(DOCKER_CMD, getNewaddress: _*)
+          .spawn[IO]
+          .use(getText)
+        _ <- IO.println("newAddress: " + newAddress)
+        _ <- process
+          .ProcessBuilder(DOCKER_CMD, generateToAddress(1, 1, newAddress): _*)
+          .spawn[IO]
+          .use(_.exitValue)
+        unspent <- process
+          .ProcessBuilder(DOCKER_CMD, extractGetTxId: _*)
+          .spawn[IO]
+          .use(getText)
+        // _ <- IO.println("unspent: " + unspent)
+        txId <- IO.fromEither(
+          parse(unspent).map(x => (x \\ "txid").head.asString.get)
+        )
+        _ <- IO.println("txId: " + txId)
+        startSessionResponse <- EmberClientBuilder
+          .default[IO]
+          .build
+          .use({ client =>
+            client.expect[StartPeginSessionResponse](
+              Request[IO](
+                method = Method.POST,
+                Uri
+                  .fromString(
+                    "http://127.0.0.1:4000/api/" + BridgeContants.START_PEGIN_SESSION_PATH
+                  )
+                  .toOption
+                  .get
+              ).withContentType(
+                `Content-Type`.apply(MediaType.application.json)
+              ).withEntity(
+                StartPeginSessionRequest(
+                  pkey =
+                    "0295bb5a3b80eeccb1e38ab2cbac2545e9af6c7012cdc8d53bd276754c54fc2e4a",
+                  sha256 = sha256ToplSecret
+                )
+              )
+            )
+          })
+        _ <- IO.println("script: " + startSessionResponse.script)
+        _ <- IO.println("Escrow address: " + startSessionResponse.escrowAddress)
+        addTemplateResult <- addTemplate(
+          sha256ToplSecret,
+          startSessionResponse.minHeight,
+          startSessionResponse.maxHeight
+        ).use { getText }
+        _ <- IO.println("addTemplateResult: " + addTemplateResult)
+        _ <- IO(Source.fromString(startSessionResponse.descriptor))
+        bitcoinTx <- process
+          .ProcessBuilder(
+            DOCKER_CMD,
+            createTx(
+              txId,
+              startSessionResponse.escrowAddress,
+              BigDecimal("49.99")
+            ): _*
+          )
+          .spawn[IO]
+          .use(getText)
+        _ <- IO.println("unspentTx: " + bitcoinTx)
+        signedTx <- process
+          .ProcessBuilder(DOCKER_CMD, signTransaction(bitcoinTx): _*)
+          .spawn[IO]
+          .use(getText)
+        signedTxHex <- IO.fromEither(
+          parse(signedTx).map(x => (x \\ "hex").head.asString.get)
+        )
+        sentTxId <- process
+          .ProcessBuilder(DOCKER_CMD, sendTransaction(signedTxHex): _*)
+          .spawn[IO]
+          .use(getText)
+        _ <- IO.println("Generating blocks..")
+        _ <- IO.println("sentTxId: " + sentTxId)
+        _ <- process
+          .ProcessBuilder(DOCKER_CMD, generateToAddress(1, 8, newAddress): _*)
+          .spawn[IO]
+          .use(_.exitValue)
+        mintingStatusResponse <- EmberClientBuilder
+          .default[IO]
+          .build
+          .use({ client =>
+            (IO.println("Requesting..") >> client
+              .expect[MintingStatusResponse](
+                Request[IO](
+                  method = Method.POST,
+                  Uri
+                    .fromString(
+                      "http://127.0.0.1:4000/api/" + BridgeContants.TOPL_MINTING_STATUS
+                    )
+                    .toOption
+                    .get
+                ).withContentType(
+                  `Content-Type`.apply(MediaType.application.json)
+                ).withEntity(
+                  MintingStatusRequest(startSessionResponse.sessionID)
+                )
+              )
+              .flatMap(x =>
+                IO.println(x.mintingStatus) >> IO.sleep(5.second) >> IO.pure(x)
+              ))
+              .iterateUntil(
+                _.mintingStatus == "PeginSessionWaitingForRedemption"
+              )
+          })
+        _ <- fs2.io
+          .readInputStream[IO](
+            IO(
+              new ByteArrayInputStream(
+                "".getBytes()
+              )
+            ),
+            10
+          )
+          .through(Files[IO].writeAll(fs2.io.file.Path(vkFile)))
+          .compile
+          .drain
+        importVkResult <- importVks.use { getText }
+        _ <- IO.println("importVkResult: " + importVkResult)
+        fundRedeemAddressTx <- fundRedeemAddressTx(
+          mintingStatusResponse.address
+        ).use { getText }
+        _ <- IO.println("fundRedeemAddressTx: " + fundRedeemAddressTx)
+        proveFundRedeemAddressTxRes <- proveFundRedeemAddressTx(
+          "fundRedeemTx.pbuf",
+          "fundRedeemTxProved.pbuf"
+        ).use { getText }
+        _ <- IO.println(
+          "proveFundRedeemAddressTxRes: " + proveFundRedeemAddressTxRes
+        )
+        broadcastFundRedeemAddressTxRes <- broadcastFundRedeemAddressTx(
+          "fundRedeemTxProved.pbuf"
+        ).use {
+          getText
+        }
+        _ <- IO.println(
+          "broadcastFundRedeemAddressTxRes: " + broadcastFundRedeemAddressTxRes
+        )
+        utxo <- getCurrentUtxosFromAddress(mintingStatusResponse.address)
+          .use(
+            getText
+          )
+          .iterateUntil(_.contains("LVL"))
+        _ <- IO.println("utxos: " + utxo)
+        groupId = utxo
+          .split("\n")
+          .filter(_.contains("GroupId"))
+          .head
+          .split(":")
+          .last
+          .trim()
+        seriesId = utxo
+          .split("\n")
+          .filter(_.contains("SeriesId"))
+          .head
+          .split(":")
+          .last
+          .trim()
+        _ <- IO.println("groupId: " + groupId)
+        _ <- IO.println("seriesId: " + seriesId)
+        currentAddress <- currentAddress.use { getText }
+        redeemAddressTx <- redeemAddressTx(
+          currentAddress,
+          4999000000L,
+          groupId,
+          seriesId
+        ).use { getText }
+        _ <- IO.println("redeemAddressTx: " + redeemAddressTx)
+        proveFundRedeemAddressTxRes <- proveFundRedeemAddressTx(
+          "redeemTx.pbuf",
+          "redeemTxProved.pbuf"
+        )
+          .use {
+            getText
+          }
+        _ <- IO.println(
+          "proveFundRedeemAddressTxRes: " + proveFundRedeemAddressTxRes
+        )
+        // disconnect networks
+        _ <- process
+          .ProcessBuilder(DOCKER_CMD, setNetworkActive(2, false): _*)
+          .spawn[IO]
+          .use { getText }
+        _ <- process
+          .ProcessBuilder(DOCKER_CMD, setNetworkActive(1, false): _*)
+          .spawn[IO]
+          .use { getText }
+        // broadcast
+        _ <- broadcastFundRedeemAddressTx("redeemTxProved.pbuf").use {
+          getText
+        }
+        utxo <- getCurrentUtxosFromAddress(currentAddress)
+          .use(
+            getText
+          )
+          .iterateUntil(_.contains("Asset"))
+        _ <- IO.println("utxos: " + utxo)
+        _ <- IO.sleep(5.second)
+        _ <- EmberClientBuilder
+          .default[IO]
+          .build
+          .use({ client =>
+            (IO.println("Requesting..") >> client
+              .expect[MintingStatusResponse](
+                Request[IO](
+                  method = Method.POST,
+                  Uri
+                    .fromString(
+                      "http://127.0.0.1:4000/api/" + BridgeContants.TOPL_MINTING_STATUS
+                    )
+                    .toOption
+                    .get
+                ).withContentType(
+                  `Content-Type`.apply(MediaType.application.json)
+                ).withEntity(
+                  MintingStatusRequest(startSessionResponse.sessionID)
+                )
+              ))
+              .flatMap(x =>
+                IO.println(x.mintingStatus) >> process
+                  .ProcessBuilder(
+                    DOCKER_CMD,
+                    generateToAddress(1, 1, newAddress): _*
+                  )
+                  .spawn[IO]
+                  .use(_.exitValue) >>
+                  IO.sleep(5.second) >> IO.pure(x)
+              )
+              .iterateUntil(
+                _.mintingStatus == "PeginSessionWaitingForClaimBTCConfirmation"
+              )
+          })
+        _ <- process
+          .ProcessBuilder(DOCKER_CMD, generateToAddress(2, 8, newAddress): _*)
+          .spawn[IO]
+          .use(_.exitValue)
+        // reconnect networks
+        _ <- process
+          .ProcessBuilder(DOCKER_CMD, setNetworkActive(2, true): _*)
+          .spawn[IO]
+          .use { getText }
+        _ <- process
+          .ProcessBuilder(DOCKER_CMD, setNetworkActive(1, true): _*)
+          .spawn[IO]
+          .use { getText }
+        // force connection
+        _ <- process
+          .ProcessBuilder(
+            DOCKER_CMD,
+            forceConnection(1, ipBitcoin02, 18444): _*
+          )
+          .spawn[IO]
+          .use { getText }
+        _ <- process
+          .ProcessBuilder(
+            DOCKER_CMD,
+            forceConnection(2, ipBitcoin01, 18444): _*
+          )
+          .spawn[IO]
+          .use { getText }
+        _ <- EmberClientBuilder
+          .default[IO]
+          .build
+          .use({ client =>
+            (IO.println("Requesting..") >> client
+              .expect[MintingStatusResponse](
+                Request[IO](
+                  method = Method.POST,
+                  Uri
+                    .fromString(
+                      "http://127.0.0.1:4000/api/" + BridgeContants.TOPL_MINTING_STATUS
+                    )
+                    .toOption
+                    .get
+                ).withContentType(
+                  `Content-Type`.apply(MediaType.application.json)
+                ).withEntity(
+                  MintingStatusRequest(startSessionResponse.sessionID)
+                )
+              ))
+              .flatMap(x =>
+                IO.println(x.mintingStatus) >> IO.sleep(5.second) >> IO.pure(x)
+              )
+              .iterateUntil(
+                _.mintingStatus == "PeginSessionWaitingForClaim"
+              )
+          })
+        _ <- IO.println(
+          s"Session ${startSessionResponse.sessionID} went back to PeginSessionWaitingForClaim again"
+        )
+      } yield (),
+      ()
+    )
+  }
+
+}

--- a/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgModule.scala
@@ -257,7 +257,7 @@ trait SuccessfulPeginWithClaimReorgModule {
         redeemAddressTx <- redeemAddressTx(
           2,
           currentAddress,
-          BigDecimal(btcAmount.toString + "99000000").toLong,
+          BigDecimal((btcAmount.toInt.get - 1).toString + "99000000").toLong,
           groupId,
           seriesId
         ).use { getText }

--- a/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgModule.scala
@@ -139,7 +139,7 @@ trait SuccessfulPeginWithClaimReorgModule {
             createTx(
               txId,
               startSessionResponse.escrowAddress,
-              BigDecimal(btcAmount)
+              BigDecimal(btcAmount) - BigDecimal("0.01")
             ): _*
           )
           .spawn[IO]
@@ -282,9 +282,10 @@ trait SuccessfulPeginWithClaimReorgModule {
           .spawn[IO]
           .use { getText }
         // broadcast
-        redeemTxProved <- broadcastFundRedeemAddressTx("redeemTxProved.pbuf").use {
-          getError
-        }
+        redeemTxProved <- broadcastFundRedeemAddressTx("redeemTxProved.pbuf")
+          .use {
+            getError
+          }
         _ <- IO.println("redeemTxProved: " + redeemTxProved)
         utxo <- getCurrentUtxosFromAddress(2, currentAddress)
           .use(

--- a/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgModule.scala
@@ -95,6 +95,9 @@ trait SuccessfulPeginWithClaimReorgModule {
         txId <- IO.fromEither(
           parse(unspent).map(x => (x \\ "txid").head.asString.get)
         )
+        btcAmount <- IO.fromEither(
+          parse(unspent).map(x => (x \\ "amount").head.asString.get)
+        )
         _ <- IO.println("txId: " + txId)
         startSessionResponse <- EmberClientBuilder
           .default[IO]
@@ -136,7 +139,7 @@ trait SuccessfulPeginWithClaimReorgModule {
             createTx(
               txId,
               startSessionResponse.escrowAddress,
-              BigDecimal("49.99")
+              BigDecimal(btcAmount)
             ): _*
           )
           .spawn[IO]

--- a/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgRetryModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgRetryModule.scala
@@ -29,7 +29,7 @@ trait SuccessfulPeginWithClaimReorgRetryModule {
     import org.typelevel.log4cats.syntax._
     val logger =
       org.typelevel.log4cats.slf4j.Slf4jLogger
-        .getLoggerFromName[IO]("successfulPeginWithClaimError")
+        .getLoggerFromName[IO]("successfulPeginWithClaimErrorRetry")
 
     assertIO(
       for {

--- a/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgRetryModule.scala
+++ b/integration/src/test/scala/co/topl/bridge/SuccessfulPeginWithClaimReorgRetryModule.scala
@@ -1,0 +1,427 @@
+package co.topl.bridge
+import cats.effect.IO
+import co.topl.shared.BridgeContants
+import co.topl.shared.MintingStatusRequest
+import co.topl.shared.MintingStatusResponse
+import co.topl.shared.StartPeginSessionRequest
+import co.topl.shared.StartPeginSessionResponse
+import fs2.io.file.Files
+import fs2.io.process
+import io.circe.parser._
+import org.http4s.Method
+import org.http4s.Request
+import org.http4s.Uri
+import org.http4s._
+import org.http4s.ember.client._
+import org.http4s.headers.`Content-Type`
+
+import java.io.ByteArrayInputStream
+import scala.concurrent.duration._
+import scala.io.Source
+
+trait SuccessfulPeginWithClaimReorgRetryModule {
+
+  // self BridgeIntegrationSpec
+  self: BridgeIntegrationSpec =>
+
+  def successfulPeginWithClaimErrorRetry(): IO[Unit] = {
+    import co.topl.bridge.implicits._
+    import org.typelevel.log4cats.syntax._
+    val logger =
+      org.typelevel.log4cats.slf4j.Slf4jLogger
+        .getLoggerFromName[IO]("successfulPeginWithClaimError")
+
+    assertIO(
+      for {
+        bridgeNetwork <- computeBridgeNetworkName
+        ipBitcoin02 <- IO.fromEither(
+          parse(bridgeNetwork)
+            .map(x =>
+              (((x.asArray.get.head \\ "Containers").head.asObject.map { x =>
+                x.filter(x => (x._2 \\ "Name").head.asString.get == "bitcoin02")
+                  .values
+                  .head
+              }).get \\ "IPv4Address").head.asString.get
+                .split("/")
+                .head
+            )
+        )
+        // print IP BTC 02
+        _ <- IO.println("ipBitcoin02: " + ipBitcoin02)
+        // parse
+        ipBitcoin01 <- IO.fromEither(
+          parse(bridgeNetwork)
+            .map(x =>
+              (((x.asArray.get.head \\ "Containers").head.asObject.map { x =>
+                x.filter(x => (x._2 \\ "Name").head.asString.get == "bitcoin01")
+                  .values
+                  .head
+              }).get \\ "IPv4Address").head.asString.get
+                .split("/")
+                .head
+            )
+        )
+        // print IP BTC 01
+        _ <- IO.println("ipBitcoin01: " + ipBitcoin01)
+        cwd <- process
+          .ProcessBuilder("pwd")
+          .spawn[IO]
+          .use { getText }
+        _ <- IO.println("cwd: " + cwd)
+        initResult <- initUserWallet(2).use { getText }
+        _ <- IO.println("initResult: " + initResult)
+        addFellowshipResult <- addFellowship(2).use { getText }
+        _ <- IO.println("addFellowshipResult: " + addFellowshipResult)
+        addSecretResult <- addSecret(2).use { getText }
+        _ <- IO.println("addSecretResult: " + addSecretResult)
+        createWalletOut <- process
+          .ProcessBuilder(DOCKER_CMD, createWallet: _*)
+          .spawn[IO]
+          .use { getText }
+        _ <- IO.println("createWalletOut: " + createWalletOut)
+        newAddress <- process // we get the new address
+          .ProcessBuilder(DOCKER_CMD, getNewaddress: _*)
+          .spawn[IO]
+          .use(getText)
+        _ <- IO.println("newAddress: " + newAddress)
+        _ <- process
+          .ProcessBuilder(DOCKER_CMD, generateToAddress(1, 1, newAddress): _*)
+          .spawn[IO]
+          .use(_.exitValue)
+        unspent <- process
+          .ProcessBuilder(DOCKER_CMD, extractGetTxId: _*)
+          .spawn[IO]
+          .use(getText)
+        txId <- IO.fromEither(
+          parse(unspent).map(x => (x \\ "txid").head.asString.get)
+        )
+        btcAmount <- IO.fromEither(
+          parse(unspent).map(x => (x \\ "amount").head.asNumber.get)
+        )
+        _ <- IO.println("txId: " + txId)
+        startSessionResponse <- EmberClientBuilder
+          .default[IO]
+          .build
+          .use({ client =>
+            client.expect[StartPeginSessionResponse](
+              Request[IO](
+                method = Method.POST,
+                Uri
+                  .fromString(
+                    "http://127.0.0.1:4000/api/" + BridgeContants.START_PEGIN_SESSION_PATH
+                  )
+                  .toOption
+                  .get
+              ).withContentType(
+                `Content-Type`.apply(MediaType.application.json)
+              ).withEntity(
+                StartPeginSessionRequest(
+                  pkey =
+                    "0295bb5a3b80eeccb1e38ab2cbac2545e9af6c7012cdc8d53bd276754c54fc2e4a",
+                  sha256 = shaSecretMap(2)
+                )
+              )
+            )
+          })
+        _ <- IO.println("script: " + startSessionResponse.script)
+        _ <- IO.println("Escrow address: " + startSessionResponse.escrowAddress)
+        addTemplateResult <- addTemplate(
+          2,
+          shaSecretMap(2),
+          startSessionResponse.minHeight,
+          startSessionResponse.maxHeight
+        ).use { getText }
+        _ <- IO.println("addTemplateResult: " + addTemplateResult)
+        _ <- IO(Source.fromString(startSessionResponse.descriptor))
+        bitcoinTx <- process
+          .ProcessBuilder(
+            DOCKER_CMD,
+            createTx(
+              txId,
+              startSessionResponse.escrowAddress,
+              btcAmount.toBigDecimal.get - BigDecimal("0.01")
+            ): _*
+          )
+          .spawn[IO]
+          .use(getText)
+        _ <- IO.println("unspentTx: " + bitcoinTx)
+        signedTx <- process
+          .ProcessBuilder(DOCKER_CMD, signTransaction(bitcoinTx): _*)
+          .spawn[IO]
+          .use(getText)
+        signedTxHex <- IO.fromEither(
+          parse(signedTx).map(x => (x \\ "hex").head.asString.get)
+        )
+        sentTxId <- process
+          .ProcessBuilder(DOCKER_CMD, sendTransaction(signedTxHex): _*)
+          .spawn[IO]
+          .use(getError)
+        _ <- IO.println("Generating blocks..")
+        _ <- IO.println("sentTxId: " + sentTxId)
+        _ <- process
+          .ProcessBuilder(DOCKER_CMD, generateToAddress(1, 8, newAddress): _*)
+          .spawn[IO]
+          .use(_.exitValue)
+        mintingStatusResponse <- EmberClientBuilder
+          .default[IO]
+          .build
+          .use({ client =>
+            (IO.println(
+              "Requesting 1.. " + "sessionId: " + startSessionResponse.sessionID
+            ) >> client
+              .expect[MintingStatusResponse](
+                Request[IO](
+                  method = Method.POST,
+                  Uri
+                    .fromString(
+                      "http://127.0.0.1:4000/api/" + BridgeContants.TOPL_MINTING_STATUS
+                    )
+                    .toOption
+                    .get
+                ).withContentType(
+                  `Content-Type`.apply(MediaType.application.json)
+                ).withEntity(
+                  MintingStatusRequest(startSessionResponse.sessionID)
+                )
+              )
+              .flatMap(x =>
+                IO.println(x.mintingStatus) >> IO.sleep(5.second) >> IO.pure(x)
+              ))
+              .iterateUntil(
+                _.mintingStatus == "PeginSessionWaitingForRedemption"
+              )
+          })
+        _ <- fs2.io
+          .readInputStream[IO](
+            IO(
+              new ByteArrayInputStream(
+                "".getBytes()
+              )
+            ),
+            10
+          )
+          .through(Files[IO].writeAll(fs2.io.file.Path(vkFile)))
+          .compile
+          .drain
+        importVkResult <- importVks(2).use { getText }
+        _ <- IO.println("importVkResult: " + importVkResult)
+        fundRedeemAddressTx <- fundRedeemAddressTx(
+          2,
+          mintingStatusResponse.address
+        ).use { getText }
+        _ <- IO.println("fundRedeemAddressTx: " + fundRedeemAddressTx)
+        proveFundRedeemAddressTxRes <- proveFundRedeemAddressTx(
+          2,
+          "fundRedeemTx.pbuf",
+          "fundRedeemTxProved.pbuf"
+        ).use { getText }
+        _ <- IO.println(
+          "proveFundRedeemAddressTxRes: " + proveFundRedeemAddressTxRes
+        )
+        broadcastFundRedeemAddressTxRes <- broadcastFundRedeemAddressTx(
+          "fundRedeemTxProved.pbuf"
+        ).use {
+          getText
+        }
+        _ <- IO.println(
+          "broadcastFundRedeemAddressTxRes: " + broadcastFundRedeemAddressTxRes
+        )
+        utxo <- (getCurrentUtxosFromAddress(2, mintingStatusResponse.address)
+          .use(
+            getText
+          )
+          .flatMap(x =>
+            info"waiting for 2 seconds" (logger) >> IO.sleep(2.second) >> IO
+              .pure(x)
+          ))
+          .iterateUntil(_.contains("LVL"))
+        _ <- IO.println("utxos: " + utxo)
+        groupId = utxo
+          .split("\n")
+          .filter(_.contains("GroupId"))
+          .head
+          .split(":")
+          .last
+          .trim()
+        seriesId = utxo
+          .split("\n")
+          .filter(_.contains("SeriesId"))
+          .head
+          .split(":")
+          .last
+          .trim()
+        _ <- IO.println("groupId: " + groupId)
+        _ <- IO.println("seriesId: " + seriesId)
+        currentAddress <- currentAddress(2).use { getText }
+        _ <- IO.println("btcAmount.toString: " + btcAmount.toString)
+        redeemAddressTx <- redeemAddressTx(
+          2,
+          currentAddress,
+          BigDecimal((btcAmount.toInt.get - 1).toString + "99000000").toLong,
+          groupId,
+          seriesId
+        ).use { getText }
+        _ <- IO.println("redeemAddressTx: " + redeemAddressTx)
+        proveFundRedeemAddressTxRes <- proveFundRedeemAddressTx(
+          2,
+          "redeemTx.pbuf",
+          "redeemTxProved.pbuf"
+        )
+          .use {
+            getText
+          }
+        _ <- IO.println(
+          "proveFundRedeemAddressTxRes: " + proveFundRedeemAddressTxRes
+        )
+        // disconnect networks
+        _ <- process
+          .ProcessBuilder(DOCKER_CMD, setNetworkActive(2, false): _*)
+          .spawn[IO]
+          .use { getText }
+        _ <- process
+          .ProcessBuilder(DOCKER_CMD, setNetworkActive(1, false): _*)
+          .spawn[IO]
+          .use { getText }
+        // broadcast
+        redeemTxProved <- broadcastFundRedeemAddressTx("redeemTxProved.pbuf")
+          .use {
+            getError
+          }
+        _ <- IO.println("redeemTxProved: " + redeemTxProved)
+        utxo <- getCurrentUtxosFromAddress(2, currentAddress)
+          .use(
+            getText
+          )
+          .iterateUntil(_.contains("Asset"))
+        _ <- IO.println("utxos: " + utxo)
+        _ <- EmberClientBuilder
+          .default[IO]
+          .build
+          .use({ client =>
+            ((IO.println("Requesting 2..") >> client
+              .expect[MintingStatusResponse](
+                Request[IO](
+                  method = Method.POST,
+                  Uri
+                    .fromString(
+                      "http://127.0.0.1:4000/api/" + BridgeContants.TOPL_MINTING_STATUS
+                    )
+                    .toOption
+                    .get
+                ).withContentType(
+                  `Content-Type`.apply(MediaType.application.json)
+                ).withEntity(
+                  MintingStatusRequest(startSessionResponse.sessionID)
+                )
+              ))
+              .flatMap(x =>
+                IO.println(x.mintingStatus) >> process
+                  .ProcessBuilder(
+                    DOCKER_CMD,
+                    generateToAddress(1, 1, newAddress): _*
+                  )
+                  .spawn[IO]
+                  .use(_.exitValue) >>
+                  IO.sleep(5.second) >> IO.pure(x)
+              ))
+              .iterateUntil(
+                _.mintingStatus == "PeginSessionWaitingForClaimBTCConfirmation"
+              )
+          })
+        _ <- process
+          .ProcessBuilder(DOCKER_CMD, generateToAddress(2, 8, newAddress): _*)
+          .spawn[IO]
+          .use(_.exitValue)
+        // reconnect networks
+        _ <- process
+          .ProcessBuilder(DOCKER_CMD, setNetworkActive(2, true): _*)
+          .spawn[IO]
+          .use { getText }
+        _ <- process
+          .ProcessBuilder(DOCKER_CMD, setNetworkActive(1, true): _*)
+          .spawn[IO]
+          .use { getText }
+        // force connection
+        _ <- process
+          .ProcessBuilder(
+            DOCKER_CMD,
+            forceConnection(1, ipBitcoin02, 18444): _*
+          )
+          .spawn[IO]
+          .use { getText }
+        _ <- process
+          .ProcessBuilder(
+            DOCKER_CMD,
+            forceConnection(2, ipBitcoin01, 18444): _*
+          )
+          .spawn[IO]
+          .use { getText }
+        _ <- EmberClientBuilder
+          .default[IO]
+          .build
+          .use({ client =>
+            (IO.println("Requesting 3..") >> client
+              .expect[MintingStatusResponse](
+                Request[IO](
+                  method = Method.POST,
+                  Uri
+                    .fromString(
+                      "http://127.0.0.1:4000/api/" + BridgeContants.TOPL_MINTING_STATUS
+                    )
+                    .toOption
+                    .get
+                ).withContentType(
+                  `Content-Type`.apply(MediaType.application.json)
+                ).withEntity(
+                  MintingStatusRequest(startSessionResponse.sessionID)
+                )
+              ))
+              .flatMap(x =>
+                IO.println(x.mintingStatus) >> IO.sleep(5.second) >> IO.pure(x)
+              )
+              .iterateUntil(
+                _.mintingStatus == "PeginSessionWaitingForClaim"
+              )
+          })
+        _ <- EmberClientBuilder
+          .default[IO]
+          .build
+          .use({ client =>
+            (IO.println("Requesting 4..") >> client
+              .status(
+                Request[IO](
+                  method = Method.POST,
+                  Uri
+                    .fromString(
+                      "http://127.0.0.1:4000/api/" + BridgeContants.TOPL_MINTING_STATUS
+                    )
+                    .toOption
+                    .get
+                ).withContentType(
+                  `Content-Type`.apply(MediaType.application.json)
+                ).withEntity(
+                  MintingStatusRequest(startSessionResponse.sessionID)
+                )
+              ))
+              .flatMap(x =>
+                IO.println(x.code) >> process
+                  .ProcessBuilder(
+                    DOCKER_CMD,
+                    generateToAddress(1, 1, newAddress): _*
+                  )
+                  .spawn[IO]
+                  .use(_.exitValue) >> IO.sleep(1.second) >> IO.pure(x)
+              )
+              .iterateUntil(
+                _.code == 404
+              )
+          })
+        _ <- IO.println(
+          s"Session ${startSessionResponse.sessionID} went back to PeginSessionWaitingForClaim again"
+        )
+      } yield (),
+      ()
+    )
+  }
+
+}

--- a/integration/src/test/scala/co/topl/bridge/package.scala
+++ b/integration/src/test/scala/co/topl/bridge/package.scala
@@ -131,15 +131,13 @@ package object bridge {
 
   def templateFromSha(sha256: String, min: Long, max: Long) =
     s"""threshold(1, sha256($sha256) and height($min, $max))"""
-  val secret = "topl-secret"
 
-  val sha256ToplSecret =
-    "ee15b31e49931db6551ed8a82f1422ce5a5a8debabe8e81a724c88f79996d0df"
+  val secretMap = Map(1 -> "topl-secret", 2 -> "topl-secret01")
 
-  val secret01 = "topl-secret01"
-
-  val sha256ToplSecret01 =
-    "b46478c2553d2972c4a79172f7b468b422c6c516a980340acf83508d478504c3"
+  val shaSecretMap = Map(
+    1 -> "ee15b31e49931db6551ed8a82f1422ce5a5a8debabe8e81a724c88f79996d0df",
+    2 -> "b46478c2553d2972c4a79172f7b468b422c6c516a980340acf83508d478504c3"
+  )
 
   // brambl-cli templates add --walletdb user-wallet.db --template-name redeemBridge --lock-template
   def addTemplate(id: Int, sha256: String, min: Long, max: Long) = process
@@ -151,7 +149,7 @@ package object bridge {
         "--walletdb",
         userWalletDb(id),
         "--template-name",
-        "redeemBridge",
+        "redeemBridge" + f"$id%02d",
         "--lock-template",
         templateFromSha(sha256, min, max)
       ): _*
@@ -172,7 +170,7 @@ package object bridge {
         "--fellowship-name",
         "bridge",
         "--template-name",
-        "redeemBridge",
+        "redeemBridge" + f"$id%02d",
         "-w",
         "password",
         "-k",
@@ -255,7 +253,7 @@ package object bridge {
         "--from-fellowship",
         "bridge",
         "--from-template",
-        "redeemBridge",
+        "redeemBridge" + f"$id%02d",
         "-t",
         redeemAddress,
         "-w",
@@ -287,7 +285,11 @@ package object bridge {
     .spawn[IO]
 
   // brambl-cli tx prove -i fundRedeemTx.pbuf --walletdb user-wallet.db --keyfile user-keyfile.json -w password -o fundRedeemTxProved.pbuf
-  def proveFundRedeemAddressTx(id: Int, fileToProve: String, provedFile: String) =
+  def proveFundRedeemAddressTx(
+      id: Int,
+      fileToProve: String,
+      provedFile: String
+  ) =
     process
       .ProcessBuilder(
         CS_CMD,

--- a/integration/src/test/scala/co/topl/bridge/package.scala
+++ b/integration/src/test/scala/co/topl/bridge/package.scala
@@ -380,6 +380,17 @@ package object bridge {
     s"$ip:$port",
     "add"
   )
+  def removeNode(nodeId: Int, ip: String, port: Int) = Seq(
+    "exec",
+    "bitcoin" + f"${nodeId}%02d",
+    "bitcoin-cli",
+    "-regtest",
+    "-rpcuser=bitcoin",
+    "-rpcpassword=password",
+    "addnode",
+    s"$ip:$port",
+    "remove"
+  )
 
   // network inspect bridge
   def inspectBridge(networkName: String) =

--- a/integration/src/test/scala/co/topl/bridge/package.scala
+++ b/integration/src/test/scala/co/topl/bridge/package.scala
@@ -129,7 +129,7 @@ package object bridge {
     )
     .spawn[IO]
 
-  def templateFromSha(sha256: String,  min: Long, max: Long) =
+  def templateFromSha(sha256: String, min: Long, max: Long) =
     s"""threshold(1, sha256($sha256) and height($min, $max))"""
   val secret = "topl-secret"
 
@@ -321,7 +321,7 @@ package object bridge {
 
   val createWallet = Seq(
     "exec",
-    "bitcoin",
+    "bitcoin01",
     "bitcoin-cli",
     "-regtest",
     "-named",
@@ -332,7 +332,7 @@ package object bridge {
   )
   val getNewaddress = Seq(
     "exec",
-    "bitcoin",
+    "bitcoin01",
     "bitcoin-cli",
     "-rpcuser=bitcoin",
     "-rpcpassword=password",
@@ -340,9 +340,9 @@ package object bridge {
     "-rpcwallet=testwallet",
     "getnewaddress"
   )
-  def generateToAddress(blocks: Int, address: String) = Seq(
+  def generateToAddress(nodeId: Int, blocks: Int, address: String) = Seq(
     "exec",
-    "bitcoin",
+    "bitcoin" + f"$nodeId%02d",
     "bitcoin-cli",
     "-regtest",
     "-rpcuser=bitcoin",
@@ -352,9 +352,40 @@ package object bridge {
     address
   )
 
+  // docker network disconnect bridge bitcoin02
+  def disconnectBridge(nodeId: Int) = Seq(
+    "network",
+    "disconnect",
+    "bridge",
+    "bitcoin" + f"${nodeId}%02d"
+  )
+
+  def connectBridge(nodeId: Int) = Seq(
+    "network",
+    "connect",
+    "bridge",
+    "bitcoin" + f"${nodeId}%02d"
+  )
+
+  // exec bitcoin01 bitcoin-cli -regtest -rpcuser=bitcoin -rpcpassword=password addnode <ip>:<port> add
+  def addNode(nodeId: Int, ip: String, port: Int) = Seq(
+    "exec",
+    "bitcoin" + f"${nodeId}%02d",
+    "bitcoin-cli",
+    "-regtest",
+    "-rpcuser=bitcoin",
+    "-rpcpassword=password",
+    "addnode",
+    s"$ip:$port",
+    "add"
+  )
+
+  // network inspect bridge
+  val inspectBridge = Seq("network", "inspect", "bridge")
+
   def createTransaction(address: String) = Seq(
     "exec",
-    "bitcoin",
+    "bitcoin01",
     "bitcoin-cli",
     "-regtest",
     "-rpcuser=bitcoin",
@@ -365,7 +396,7 @@ package object bridge {
   )
   def signTransaction(tx: String) = Seq(
     "exec",
-    "bitcoin",
+    "bitcoin01",
     "bitcoin-cli",
     "-regtest",
     "-rpcuser=bitcoin",
@@ -376,7 +407,7 @@ package object bridge {
   )
   def sendTransaction(signedTx: String) = Seq(
     "exec",
-    "bitcoin",
+    "bitcoin01",
     "bitcoin-cli",
     "-regtest",
     "-rpcuser=bitcoin",
@@ -387,7 +418,7 @@ package object bridge {
 
   val extractGetTxId = Seq(
     "exec",
-    "bitcoin",
+    "bitcoin01",
     "bitcoin-cli",
     "-rpcuser=bitcoin",
     "-rpcpassword=password",
@@ -398,7 +429,7 @@ package object bridge {
 
   def createTx(txId: String, address: String, amount: BigDecimal) = Seq(
     "exec",
-    "bitcoin",
+    "bitcoin01",
     "bitcoin-tx",
     "-regtest",
     "-create",

--- a/integration/src/test/scala/co/topl/bridge/package.scala
+++ b/integration/src/test/scala/co/topl/bridge/package.scala
@@ -391,7 +391,7 @@ package object bridge {
     s"$ip:$port",
     "add"
   )
-  def removeNode(nodeId: Int, ip: String, port: Int) = Seq(
+  def forceConnection(nodeId: Int, ip: String, port: Int) = Seq(
     "exec",
     "bitcoin" + f"${nodeId}%02d",
     "bitcoin-cli",
@@ -400,7 +400,7 @@ package object bridge {
     "-rpcpassword=password",
     "addnode",
     s"$ip:$port",
-    "remove"
+    "onetry"
   )
 
   // network inspect bridge

--- a/integration/src/test/scala/co/topl/bridge/package.scala
+++ b/integration/src/test/scala/co/topl/bridge/package.scala
@@ -381,7 +381,7 @@ package object bridge {
   )
 
   // network inspect bridge
-  val inspectBridge = Seq("network", "inspect", "bridge")
+  def inspectBridge(networkName: String) = Seq("network", "inspect", networkName)
 
   // docker network ls
   val networkLs = Seq("network", "ls")

--- a/integration/src/test/scala/co/topl/bridge/package.scala
+++ b/integration/src/test/scala/co/topl/bridge/package.scala
@@ -352,15 +352,26 @@ package object bridge {
     address
   )
 
-
   // docker network disconnect bridge bitcoin02
-  def disconnectBridge(nodeId: Int, bridgeNetwork: String) = Seq(
-    "network",
-    "disconnect",
-    bridgeNetwork,
-    "bitcoin" + f"${nodeId}%02d"
-  )
+  def disconnectBridge(nodeId: Int, bridgeNetwork: String) =
+    Seq(
+      "network",
+      "disconnect",
+      bridgeNetwork,
+      "bitcoin" + f"${nodeId}%02d"
+    )
 
+  def setNetworkActive(nodeId: Int, state: Boolean) = Seq(
+    "exec",
+    "bitcoin" + f"${nodeId}%02d",
+    "bitcoin-cli",
+    "-regtest",
+    "-rpcuser=bitcoin",
+    "-rpcpassword=password",
+    "setnetworkactive",
+    state.toString
+  )  
+  
   def connectBridge(nodeId: Int, bridgeNetwork: String) = Seq(
     "network",
     "connect",

--- a/integration/src/test/scala/co/topl/bridge/package.scala
+++ b/integration/src/test/scala/co/topl/bridge/package.scala
@@ -383,6 +383,9 @@ package object bridge {
   // network inspect bridge
   val inspectBridge = Seq("network", "inspect", "bridge")
 
+  // docker network ls
+  val networkLs = Seq("network", "ls")
+
   def createTransaction(address: String) = Seq(
     "exec",
     "bitcoin01",

--- a/integration/src/test/scala/co/topl/bridge/package.scala
+++ b/integration/src/test/scala/co/topl/bridge/package.scala
@@ -370,8 +370,8 @@ package object bridge {
     "-rpcpassword=password",
     "setnetworkactive",
     state.toString
-  )  
-  
+  )
+
   def connectBridge(nodeId: Int, bridgeNetwork: String) = Seq(
     "network",
     "connect",

--- a/integration/src/test/scala/co/topl/bridge/package.scala
+++ b/integration/src/test/scala/co/topl/bridge/package.scala
@@ -46,11 +46,11 @@ package object bridge {
     "--"
   )
 
-  val userWalletDb = "user-wallet.db"
+  def userWalletDb(id: Int) = "user-wallet" + f"$id%02d" + ".db"
 
-  val userWalletMnemonic = "user-wallet-mnemonic.txt"
+  def userWalletMnemonic(id: Int) = "user-wallet-mnemonic" + f"$id%02d" + ".txt"
 
-  val userWalletJson = "user-wallet.json"
+  def userWalletJson(id: Int) = "user-wallet" + f"$id%02d" + ".json"
 
   val vkFile = "key.txt"
 
@@ -72,14 +72,14 @@ package object bridge {
     )
     .spawn[IO]
 
-  val addSecret = process
+  def addSecret(id: Int) = process
     .ProcessBuilder(
       CS_CMD,
       csParams ++ Seq(
         "wallet",
         "add-secret",
         "--walletdb",
-        userWalletDb,
+        userWalletDb(id),
         "--secret",
         "topl-secret",
         "--digest",
@@ -89,7 +89,7 @@ package object bridge {
     .spawn[IO]
 
   // brambl-cli wallet init --network private --password password --newwalletdb user-wallet.db --mnemonicfile user-wallet-mnemonic.txt --output user-wallet.json
-  val initUserWallet = process
+  def initUserWallet(id: Int) = process
     .ProcessBuilder(
       CS_CMD,
       csParams ++ Seq(
@@ -100,16 +100,16 @@ package object bridge {
         "--password",
         "password",
         "--newwalletdb",
-        userWalletDb,
+        userWalletDb(id),
         "--mnemonicfile",
-        userWalletMnemonic,
+        userWalletMnemonic(id),
         "--output",
-        userWalletJson
+        userWalletJson(id)
       ): _*
     )
     .spawn[IO]
 
-  def getCurrentUtxosFromAddress(address: String) = process
+  def getCurrentUtxosFromAddress(id: Int, address: String) = process
     .ProcessBuilder(
       CS_CMD,
       csParams ++ Seq(
@@ -122,7 +122,7 @@ package object bridge {
         "--secure",
         "false",
         "--walletdb",
-        userWalletDb,
+        userWalletDb(id),
         "--from-address",
         address
       ): _*
@@ -137,14 +137,14 @@ package object bridge {
     "ee15b31e49931db6551ed8a82f1422ce5a5a8debabe8e81a724c88f79996d0df"
 
   // brambl-cli templates add --walletdb user-wallet.db --template-name redeemBridge --lock-template
-  def addTemplate(sha256: String, min: Long, max: Long) = process
+  def addTemplate(id: Int, sha256: String, min: Long, max: Long) = process
     .ProcessBuilder(
       CS_CMD,
       csParams ++ Seq(
         "templates",
         "add",
         "--walletdb",
-        userWalletDb,
+        userWalletDb(id),
         "--template-name",
         "redeemBridge",
         "--lock-template",
@@ -154,14 +154,14 @@ package object bridge {
     .spawn[IO]
 
   // brambl-cli wallet import-vks --walletdb user-wallet.db --input-vks key.txt --fellowship-name bridge --template-name redeemBridge -w password -k user-wallet.json
-  val importVks = process
+  def importVks(id: Int) = process
     .ProcessBuilder(
       CS_CMD,
       csParams ++ Seq(
         "wallet",
         "import-vks",
         "--walletdb",
-        userWalletDb,
+        userWalletDb(id),
         "--input-vks",
         vkFile,
         "--fellowship-name",
@@ -171,26 +171,26 @@ package object bridge {
         "-w",
         "password",
         "-k",
-        userWalletJson
+        userWalletJson(id)
       ): _*
     )
     .spawn[IO]
 
   // brambl-cli wallet current-address --walletdb user-wallet.db
-  val currentAddress = process
+  def currentAddress(id: Int) = process
     .ProcessBuilder(
       CS_CMD,
       csParams ++ Seq(
         "wallet",
         "current-address",
         "--walletdb",
-        userWalletDb
+        userWalletDb(id)
       ): _*
     )
     .spawn[IO]
 
   // brambl-cli simple-transaction create --from-fellowship nofellowship --from-template genesis --from-interaction 1 -t ptetP7jshHTzLLp81RbPkeHKWFJWeE3ijH94TAmiBRPTUTj2htC31NyEWU8p -w password -o genesisTx.pbuf -n private -a 10 -h  localhost --port 9084  --keyfile user-keyfile.json --walletdb user-wallet.db --fee 10 --transfer-token lvl
-  def fundRedeemAddressTx(redeemAddress: String) = process
+  def fundRedeemAddressTx(id: Int, redeemAddress: String) = process
     .ProcessBuilder(
       CS_CMD,
       csParams ++ Seq(
@@ -223,9 +223,9 @@ package object bridge {
         "--port",
         "9084",
         "--keyfile",
-        userWalletJson,
+        userWalletJson(id),
         "--walletdb",
-        userWalletDb,
+        userWalletDb(id),
         "--fee",
         "10",
         "--transfer-token",
@@ -236,6 +236,7 @@ package object bridge {
 
   // brambl-cli simple-transaction create --from-fellowship bridge --from-template redeemBridge -t ptetP7jshHTzLLp81RbPkeHKWFJWeE3ijH94TAmiBRPTUTj2htC31NyEWU8p -w password -o redeemTx.pbuf -n private -a 10 -h  localhost --port 9084  --keyfile user-keyfile.json --walletdb user-wallet.db --fee 10 --transfer-token asset
   def redeemAddressTx(
+      id: Int,
       redeemAddress: String,
       amount: Long,
       groupId: String,
@@ -265,9 +266,9 @@ package object bridge {
         "--port",
         "9084",
         "--keyfile",
-        userWalletJson,
+        userWalletJson(id),
         "--walletdb",
-        userWalletDb,
+        userWalletDb(id),
         "--fee",
         "10",
         "--transfer-token",
@@ -281,7 +282,7 @@ package object bridge {
     .spawn[IO]
 
   // brambl-cli tx prove -i fundRedeemTx.pbuf --walletdb user-wallet.db --keyfile user-keyfile.json -w password -o fundRedeemTxProved.pbuf
-  def proveFundRedeemAddressTx(fileToProve: String, provedFile: String) =
+  def proveFundRedeemAddressTx(id: Int, fileToProve: String, provedFile: String) =
     process
       .ProcessBuilder(
         CS_CMD,
@@ -291,9 +292,9 @@ package object bridge {
           "-i",
           fileToProve, // "fundRedeemTx.pbuf",
           "--walletdb",
-          userWalletDb,
+          userWalletDb(id),
           "--keyfile",
-          userWalletJson,
+          userWalletJson(id),
           "-w",
           "password",
           "-o",
@@ -450,7 +451,7 @@ package object bridge {
       .foldMonoid
 
   // brambl-cli fellowships add --walletdb user-wallet.db --fellowship-name bridge
-  val addFellowship = process
+  def addFellowship(id: Int) = process
     .ProcessBuilder(
       CS_CMD,
       Seq(
@@ -462,7 +463,7 @@ package object bridge {
         "fellowships",
         "add",
         "--walletdb",
-        "user-wallet.db",
+        userWalletDb(id),
         "--fellowship-name",
         "bridge"
       ): _*

--- a/integration/src/test/scala/co/topl/bridge/package.scala
+++ b/integration/src/test/scala/co/topl/bridge/package.scala
@@ -136,6 +136,11 @@ package object bridge {
   val sha256ToplSecret =
     "ee15b31e49931db6551ed8a82f1422ce5a5a8debabe8e81a724c88f79996d0df"
 
+  val secret01 = "topl-secret01"
+
+  val sha256ToplSecret01 =
+    "b46478c2553d2972c4a79172f7b468b422c6c516a980340acf83508d478504c3"
+
   // brambl-cli templates add --walletdb user-wallet.db --template-name redeemBridge --lock-template
   def addTemplate(id: Int, sha256: String, min: Long, max: Long) = process
     .ProcessBuilder(

--- a/integration/src/test/scala/co/topl/bridge/package.scala
+++ b/integration/src/test/scala/co/topl/bridge/package.scala
@@ -352,18 +352,19 @@ package object bridge {
     address
   )
 
+
   // docker network disconnect bridge bitcoin02
-  def disconnectBridge(nodeId: Int) = Seq(
+  def disconnectBridge(nodeId: Int, bridgeNetwork: String) = Seq(
     "network",
     "disconnect",
-    "bridge",
+    bridgeNetwork,
     "bitcoin" + f"${nodeId}%02d"
   )
 
-  def connectBridge(nodeId: Int) = Seq(
+  def connectBridge(nodeId: Int, bridgeNetwork: String) = Seq(
     "network",
     "connect",
-    "bridge",
+    bridgeNetwork,
     "bitcoin" + f"${nodeId}%02d"
   )
 
@@ -381,7 +382,8 @@ package object bridge {
   )
 
   // network inspect bridge
-  def inspectBridge(networkName: String) = Seq("network", "inspect", networkName)
+  def inspectBridge(networkName: String) =
+    Seq("network", "inspect", networkName)
 
   // docker network ls
   val networkLs = Seq("network", "ls")

--- a/integration/src/test/scala/co/topl/bridge/package.scala
+++ b/integration/src/test/scala/co/topl/bridge/package.scala
@@ -352,15 +352,6 @@ package object bridge {
     address
   )
 
-  // docker network disconnect bridge bitcoin02
-  def disconnectBridge(nodeId: Int, bridgeNetwork: String) =
-    Seq(
-      "network",
-      "disconnect",
-      bridgeNetwork,
-      "bitcoin" + f"${nodeId}%02d"
-    )
-
   def setNetworkActive(nodeId: Int, state: Boolean) = Seq(
     "exec",
     "bitcoin" + f"${nodeId}%02d",
@@ -370,13 +361,6 @@ package object bridge {
     "-rpcpassword=password",
     "setnetworkactive",
     state.toString
-  )
-
-  def connectBridge(nodeId: Int, bridgeNetwork: String) = Seq(
-    "network",
-    "connect",
-    bridgeNetwork,
-    "bitcoin" + f"${nodeId}%02d"
   )
 
   // exec bitcoin01 bitcoin-cli -regtest -rpcuser=bitcoin -rpcpassword=password addnode <ip>:<port> add
@@ -410,17 +394,6 @@ package object bridge {
   // docker network ls
   val networkLs = Seq("network", "ls")
 
-  def createTransaction(address: String) = Seq(
-    "exec",
-    "bitcoin01",
-    "bitcoin-cli",
-    "-regtest",
-    "-rpcuser=bitcoin",
-    "-rpcpassword=password",
-    "generatetoaddress",
-    "101",
-    address
-  )
   def signTransaction(tx: String) = Seq(
     "exec",
     "bitcoin01",

--- a/shared/src/main/scala/co/topl/shared/ParamParser.scala
+++ b/shared/src/main/scala/co/topl/shared/ParamParser.scala
@@ -6,6 +6,10 @@ import org.bitcoins.core.currency.SatoshisLong
 import scala.util.Try
 import scala.util.Success
 import scala.util.Failure
+import co.topl.brambl.utils.Encoding
+import co.topl.brambl.models.GroupId
+import co.topl.brambl.models.SeriesId
+import com.google.protobuf.ByteString
 
 object ParamParser {
 
@@ -40,5 +44,25 @@ object ParamParser {
             "Could not conver value to satoshi"
           )
       })
+
+  implicit val groupIdRead: scopt.Read[GroupId] =
+    scopt.Read.reads { x =>
+      val array = Encoding.decodeFromHex(x).toOption match {
+        case Some(value) => value
+        case None =>
+          throw new IllegalArgumentException("Invalid group id")
+      }
+      GroupId(ByteString.copyFrom(array))
+    }
+
+  implicit val seriesIdRead: scopt.Read[SeriesId] =
+    scopt.Read.reads { x =>
+      val array = Encoding.decodeFromHex(x).toOption match {
+        case Some(value) => value
+        case None =>
+          throw new IllegalArgumentException("Invalid series id")
+      }
+      SeriesId(ByteString.copyFrom(array))
+    }
 
 }

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/BridgeParamsDescriptor.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/BridgeParamsDescriptor.scala
@@ -136,7 +136,17 @@ trait BridgeParamsDescriptor {
           if (x > 0.satoshis) success
           else failure("Fee per byte must be stricly greater than 0")
         )
-        .text("The fee per byte in satoshis. (optional)")
+        .text("The fee per byte in satoshis. (optional)"),
+      opt[Int]("btc-confirmation-threshold")
+        .action((x, c) => c.copy(btcConfirmationThreshold = x))
+        .text(
+          "The number of confirmations required for a peg-in transaction. (mandatory)"
+        )
+        .validate( // check that it is a positive number
+          x =>
+            if (x > 0) success
+            else failure("Confirmation threshold must be a positive number")
+        )
     )
   }
 

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/BridgeParamsDescriptor.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/BridgeParamsDescriptor.scala
@@ -5,6 +5,8 @@ import scopt.OParser
 import co.topl.shared.ToplNetworkIdentifiers
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.currency.SatoshisLong
+import co.topl.brambl.models.SeriesId
+import co.topl.brambl.models.GroupId
 
 trait BridgeParamsDescriptor {
 
@@ -137,6 +139,12 @@ trait BridgeParamsDescriptor {
           else failure("Fee per byte must be stricly greater than 0")
         )
         .text("The fee per byte in satoshis. (optional)"),
+      opt[GroupId]("abtc-group-id")
+        .action((x, c) => c.copy(groupId = x))
+        .text("Group id of ."),
+      opt[SeriesId]("abtc-series-id")
+        .action((x, c) => c.copy(seriesId = x))
+        .text("Series id."),
       opt[Int]("btc-confirmation-threshold")
         .action((x, c) => c.copy(btcConfirmationThreshold = x))
         .text(

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/BridgeParamsDescriptor.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/BridgeParamsDescriptor.scala
@@ -141,10 +141,12 @@ trait BridgeParamsDescriptor {
         .text("The fee per byte in satoshis. (optional)"),
       opt[GroupId]("abtc-group-id")
         .action((x, c) => c.copy(groupId = x))
-        .text("Group id of ."),
+        .text("Group id of the aBTC asset.")
+        .required(),
       opt[SeriesId]("abtc-series-id")
         .action((x, c) => c.copy(seriesId = x))
-        .text("Series id."),
+        .text("Series id of the aBTC asset.")
+        .required(),
       opt[Int]("btc-confirmation-threshold")
         .action((x, c) => c.copy(btcConfirmationThreshold = x))
         .text(

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/Main.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/Main.scala
@@ -36,6 +36,8 @@ case object PeginSessionState {
   case object PeginSessionWaitingForClaim extends PeginSessionState
   case object PeginSessionWaitingForEscrowBTCConfirmation
       extends PeginSessionState
+  case object PeginSessionWaitingForClaimBTCConfirmation
+      extends PeginSessionState
 }
 
 object Main extends IOApp with BridgeParamsDescriptor with AppModule {

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/Main.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/Main.scala
@@ -225,7 +225,7 @@ object Main extends IOApp with BridgeParamsDescriptor with AppModule {
         .withLogger(logger)
         .build
         .allocated
-        .both(init.setupWallet(defaultFromFellowship, defaultFromTemplate))
+        .both(init.setupWallet(defaultFromFellowship, defaultFromTemplate, params.groupId, params.seriesId))
     } yield {
       Right(
         s"Server started on ${ServerConfig.host}:${ServerConfig.port}"

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/Main.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/Main.scala
@@ -34,6 +34,8 @@ case object PeginSessionState {
   case object PeginSessionStateMintingTBTC extends PeginSessionState
   case object PeginSessionWaitingForRedemption extends PeginSessionState
   case object PeginSessionWaitingForClaim extends PeginSessionState
+  case object PeginSessionWaitingForEscrowBTCConfirmation
+      extends PeginSessionState
 }
 
 object Main extends IOApp with BridgeParamsDescriptor with AppModule {
@@ -109,6 +111,10 @@ object Main extends IOApp with BridgeParamsDescriptor with AppModule {
       _ <- info"topl-blocks-to-recover : ${params.toplWaitExpirationTime}" (
         logger
       )
+      _ <-
+        info"btc-confirmation-threshold : ${params.btcConfirmationThreshold}" (
+          logger
+        )
       _ <- info"btc-peg-in-seed-file   : ${params.btcPegInSeedFile}" (logger)
       _ <- info"btc-peg-in-password    : ******" (logger)
       _ <- info"wallet-seed-file       : ${params.btcWalletSeedFile}" (logger)
@@ -125,7 +131,9 @@ object Main extends IOApp with BridgeParamsDescriptor with AppModule {
       _ <- info"topl-network           : ${params.toplNetwork}" (logger)
       _ <- info"topl-host              : ${params.toplHost}" (logger)
       _ <- info"topl-port              : ${params.toplPort}" (logger)
-      _ <- info"topl-secure-connection : ${params.toplSecureConnection}" (logger)
+      _ <- info"topl-secure-connection : ${params.toplSecureConnection}" (
+        logger
+      )
       _ <- info"minting-fee            : ${params.mintingFee}" (logger)
       _ <- info"fee-per-byte           : ${params.feePerByte}" (logger)
       globalState <- Ref[IO].of(

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/ToplBTCBridgeParamConfig.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/ToplBTCBridgeParamConfig.scala
@@ -32,6 +32,7 @@ case class ToplBTCBridgeParamConfig(
     toplNetwork: ToplNetworkIdentifiers = ToplPrivatenet,
     toplHost: String = "localhost",
     toplPort: Int = 9084,
+    btcRetryThreshold: Int = 6,
     mintingFee: Long = 10,
     feePerByte: CurrencyUnit = 2.satoshis,
     groupId: GroupId,

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/ToplBTCBridgeParamConfig.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/ToplBTCBridgeParamConfig.scala
@@ -10,6 +10,7 @@ import org.bitcoins.core.currency.SatoshisLong
 case class ToplBTCBridgeParamConfig(
     btcWaitExpirationTime: Int =
       100, // the number of blocks to wait before the user can reclaim their funds
+    btcConfirmationThreshold: Int = 6, // the number of confirmations required for a peg-in transaction
     toplWaitExpirationTime: Int =
       2000, // the number of blocks to wait before the user can reclaim their funds
     btcPegInSeedFile: String = "pegin-wallet.json",

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/ToplBTCBridgeParamConfig.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/ToplBTCBridgeParamConfig.scala
@@ -6,11 +6,14 @@ import co.topl.shared.ToplNetworkIdentifiers
 import co.topl.shared.ToplPrivatenet
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.currency.SatoshisLong
+import co.topl.brambl.models.SeriesId
+import co.topl.brambl.models.GroupId
 
 case class ToplBTCBridgeParamConfig(
     btcWaitExpirationTime: Int =
       100, // the number of blocks to wait before the user can reclaim their funds
-    btcConfirmationThreshold: Int = 6, // the number of confirmations required for a peg-in transaction
+    btcConfirmationThreshold: Int =
+      6, // the number of confirmations required for a peg-in transaction
     toplWaitExpirationTime: Int =
       2000, // the number of blocks to wait before the user can reclaim their funds
     btcPegInSeedFile: String = "pegin-wallet.json",
@@ -31,5 +34,7 @@ case class ToplBTCBridgeParamConfig(
     toplPort: Int = 9084,
     mintingFee: Long = 10,
     feePerByte: CurrencyUnit = 2.satoshis,
+    groupId: GroupId,
+    seriesId: SeriesId,
     toplSecureConnection: Boolean = false
 )

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/modules/AppModule.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/modules/AppModule.scala
@@ -35,6 +35,7 @@ import org.typelevel.log4cats.SelfAwareStructuredLogger
 import java.util.concurrent.ConcurrentHashMap
 import co.topl.bridge.BTCWaitExpirationTime
 import co.topl.bridge.ToplWaitExpirationTime
+import co.topl.bridge.BTCConfirmationThreshold
 
 trait AppModule
     extends WalletStateResource
@@ -95,6 +96,9 @@ trait AppModule
     )
     implicit val toplWaitExpirationTime = new ToplWaitExpirationTime(
       params.toplWaitExpirationTime
+    )
+    implicit val btcConfirmationThreshold = new BTCConfirmationThreshold(
+      params.btcConfirmationThreshold
     )
     for {
       keyPair <- walletManagementUtils.loadKeys(

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/modules/AppModule.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/modules/AppModule.scala
@@ -38,6 +38,7 @@ import java.util.concurrent.ConcurrentHashMap
 import co.topl.bridge.BTCWaitExpirationTime
 import co.topl.bridge.ToplWaitExpirationTime
 import co.topl.bridge.BTCConfirmationThreshold
+import co.topl.bridge.BTCRetryThreshold
 
 trait AppModule
     extends WalletStateResource
@@ -63,6 +64,7 @@ trait AppModule
       fromFellowship: Fellowship,
       fromTemplate: Template,
       bitcoindInstance: BitcoindRpcClient,
+      btcRetryThreshold: BTCRetryThreshold,
       groupIdIdentifier: GroupId,
       seriesIdIdentifier: SeriesId
   ) = {

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/modules/AppModule.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/modules/AppModule.scala
@@ -31,6 +31,8 @@ import org.http4s.dsl.io._
 import org.http4s.server.Router
 import org.http4s.server.staticcontent.resourceServiceBuilder
 import org.typelevel.log4cats.SelfAwareStructuredLogger
+import co.topl.brambl.models.SeriesId
+import co.topl.brambl.models.GroupId
 
 import java.util.concurrent.ConcurrentHashMap
 import co.topl.bridge.BTCWaitExpirationTime
@@ -60,7 +62,9 @@ trait AppModule
   )(implicit
       fromFellowship: Fellowship,
       fromTemplate: Template,
-      bitcoindInstance: BitcoindRpcClient
+      bitcoindInstance: BitcoindRpcClient,
+      groupIdIdentifier: GroupId,
+      seriesIdIdentifier: SeriesId
   ) = {
     val staticAssetsService = resourceServiceBuilder[IO]("/static").toRoutes
     val walletKeyApi = WalletKeyApi.make[IO]()

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/modules/InitializationModule.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/modules/InitializationModule.scala
@@ -19,6 +19,8 @@ import co.topl.genus.services.Txo
 import org.typelevel.log4cats.Logger
 import quivr.models.Int128
 import quivr.models.KeyPair
+import co.topl.brambl.models.SeriesId
+import co.topl.brambl.models.GroupId
 
 import scala.concurrent.duration._
 import cats.effect.kernel.Resource
@@ -29,7 +31,9 @@ trait InitializationModuleAlgebra[F[_]] {
 
   def setupWallet(
       fromFellowship: Fellowship,
-      fromTemplate: Template
+      fromTemplate: Template,
+      groupId: GroupId,
+      seriesId: SeriesId
   ): F[Unit]
 
 }
@@ -186,170 +190,23 @@ object InitializationModule {
         }
     } yield ()
 
-    private def mintGroupToken(
-        fromFellowship: Fellowship,
-        fromTemplate: Template
-    ): F[Unit] = (for {
-      _ <- info"Minting Group Token"
-      txos <- getTxos(fromFellowship, fromTemplate)
-      lockAddress <- wsa.getCurrentAddress
-      someLock <- wsa.getLockByAddress(lockAddress)
-      _ = assert(
-        someLock.isDefined,
-        "Indices not found while minting group token"
-      )
-      _ = assert(
-        txos.filter(_.transactionOutput.value.value.isLvl).nonEmpty,
-        "No LVLs found while minting group token"
-      )
-      someChangeIdx <- wsa.getNextIndicesForFunds(
-        fromFellowship.underlying,
-        fromTemplate.underlying
-      )
-      _ = assert(
-        someChangeIdx.isDefined,
-        "Change lock not found while minting group token"
-      )
-      someChangeLock <- getChangeLockPredicate[F](
-        someChangeIdx,
-        fromFellowship,
-        fromTemplate
-      )
-      ioTx <- buildGroupTx(
-        txos.filter(_.transactionOutput.value.value.isLvl),
-        txos.filterNot(_.transactionOutput.value.value.isLvl),
-        someLock.get,
-        1,
-        10,
-        someChangeIdx,
-        keyPair,
-        Event.GroupPolicy(
-          "tBTC",
-          txos
-            .filter(_.transactionOutput.value.value.isLvl)
-            .map(x =>
-              TransactionOutputAddress(
-                x.outputAddress.network,
-                x.outputAddress.ledger,
-                x.outputAddress.index,
-                x.outputAddress.id
-              )
-            )
-            .head,
-          None
-        ),
-        someChangeLock
-      )
-      provedTx <- proveSimpleTransactionFromParams(
-        ioTx,
-        keyPair
-      )
-      _ = assert(
-        provedTx.isRight,
-        "Error proving transaction while minting group token"
-      )
-      eitherSentTx <- broadcastSimpleTransactionFromParams(
-        provedTx.toOption.get
-      )
-      _ <- Async[F].fromEither(eitherSentTx) // if this fails we should retry
-      _ <- checkIfGroupTokenMinted(fromFellowship, fromTemplate)
-
-    } yield ()).handleErrorWith { e =>
-      e.printStackTrace()
-      error"Error setting up wallet: ${e}" >>
-        error"Retrying in 5 seconds" >>
-        Async[F].sleep(
-          5.second
-        ) >> mintGroupToken(fromFellowship, fromTemplate)
-    }
-
-    private def mintSeriesToken(
-        fromFellowship: Fellowship,
-        fromTemplate: Template
-    ): F[Unit] = (for {
-      _ <- info"Minting Series Token"
-      txos <- getTxos(fromFellowship, fromTemplate)
-      lockAddress <- wsa.getCurrentAddress
-      someLock <- wsa.getLockByAddress(lockAddress)
-      _ = assert(
-        someLock.isDefined,
-        "Indices not found while minting series token"
-      )
-      _ = assert(
-        txos.filter(_.transactionOutput.value.value.isGroup).nonEmpty,
-        "No Group Tokens found while minting series token"
-      )
-      someChangeIdx <- wsa.getNextIndicesForFunds(
-        fromFellowship.underlying,
-        fromTemplate.underlying
-      )
-      _ = assert(
-        someChangeIdx.isDefined,
-        "Change lock not found while minting series token"
-      )
-      someChangeLock <- getChangeLockPredicate[F](
-        someChangeIdx,
-        fromFellowship,
-        fromTemplate
-      )
-      ioTx <- buildSeriesTx(
-        txos.filter(_.transactionOutput.value.value.isGroup),
-        txos.filterNot(_.transactionOutput.value.value.isGroup),
-        someLock.get,
-        1L,
-        10L,
-        someChangeIdx,
-        keyPair,
-        Event.SeriesPolicy(
-          "tBTC Series",
-          None,
-          txos
-            .filter(_.transactionOutput.value.value.isLvl)
-            .map(x =>
-              TransactionOutputAddress(
-                x.outputAddress.network,
-                x.outputAddress.ledger,
-                x.outputAddress.index,
-                x.outputAddress.id
-              )
-            )
-            .head
-        ),
-        someChangeLock
-      )
-      provedTx <- proveSimpleTransactionFromParams(
-        ioTx,
-        keyPair
-      )
-      _ = assert(
-        provedTx.isRight,
-        "Error proving transaction while minting series token"
-      )
-      eitherSentTx <- broadcastSimpleTransactionFromParams(
-        provedTx.toOption.get
-      )
-      _ <- Async[F].fromEither(eitherSentTx) // if this fails we should retry
-      _ <- checkIfSeriesTokenMinted(fromFellowship, fromTemplate)
-
-    } yield ()).handleErrorWith { e =>
-      e.printStackTrace
-      error"Error setting up wallet: ${e}" >>
-        error"Retrying in 5 seconds" >>
-        Async[F].sleep(
-          5.second
-        ) >> mintSeriesToken(fromFellowship, fromTemplate)
-    }
-
     private def checkForGroupToken(
         fromFellowship: Fellowship,
-        fromTemplate: Template
+        fromTemplate: Template,
+        groupId: GroupId
     ): F[Boolean] = (
       for {
         _ <- info"Checking for Group Tokens"
         txos <- getTxos(fromFellowship, fromTemplate)
         groupTxos = txos.filter(_.transactionOutput.value.value.isGroup)
         hasGroupToken <-
-          if (groupTxos.nonEmpty) {
+          if (
+            groupTxos
+              .filter(
+                _.transactionOutput.value.value.group.get.groupId == groupId
+              )
+              .nonEmpty
+          ) {
             (info"Found Group Tokens" >> currentState
               .update(
                 _.copy(
@@ -383,13 +240,21 @@ object InitializationModule {
 
     private def checkForSeriesToken(
         fromFellowship: Fellowship,
-        fromTemplate: Template
+        fromTemplate: Template,
+        seriesId: SeriesId
     ): F[Boolean] = (
       for {
         _ <- info"Checking for Series Tokens"
         txos <- getTxos(fromFellowship, fromTemplate)
+        seriesTxos = txos.filter(_.transactionOutput.value.value.isSeries)
         hasSeriesToken <-
-          if (txos.filter(_.transactionOutput.value.value.isSeries).nonEmpty) {
+          if (
+            seriesTxos
+              .filter(
+                _.transactionOutput.value.value.series.get.seriesId == seriesId
+              )
+              .nonEmpty
+          ) {
             (info"Found Series Tokens: ${int128AsBigInt(sumLvls(txos))}" >> currentState
               .update(
                 _.copy(
@@ -415,17 +280,28 @@ object InitializationModule {
 
     def setupWallet(
         fromFellowship: Fellowship,
-        fromTemplate: Template
+        fromTemplate: Template,
+        groupId: GroupId,
+        seriesId: SeriesId
     ): F[Unit] = {
       (for {
         _ <- checkForLvls(fromFellowship, fromTemplate)
-        hasGroupToken <- checkForGroupToken(fromFellowship, fromTemplate)
+        hasGroupToken <- checkForGroupToken(
+          fromFellowship,
+          fromTemplate,
+          groupId
+        )
         _ <-
-          if (!hasGroupToken) mintGroupToken(fromFellowship, fromTemplate)
+          if (!hasGroupToken)
+            error"There is no group token"
           else Async[F].unit
-        hasSeriesToken <- checkForSeriesToken(fromFellowship, fromTemplate)
+        hasSeriesToken <- checkForSeriesToken(
+          fromFellowship,
+          fromTemplate,
+          seriesId
+        )
         _ <-
-          if (!hasSeriesToken) mintSeriesToken(fromFellowship, fromTemplate)
+          if (!hasSeriesToken) error"There is no series token"
           else Async[F].unit
         _ <- setBlochainHeight()
       } yield ()).handleErrorWith { e =>

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/modules/InitializationModule.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/modules/InitializationModule.scala
@@ -5,27 +5,20 @@ import cats.effect.kernel.Ref
 import co.topl.brambl.builders.TransactionBuilderApi
 import co.topl.brambl.dataApi.GenusQueryAlgebra
 import co.topl.brambl.dataApi.WalletStateAlgebra
-import co.topl.brambl.models.Event
-import co.topl.brambl.models.TransactionOutputAddress
+import co.topl.brambl.models.GroupId
+import co.topl.brambl.models.SeriesId
 import co.topl.brambl.syntax._
 import co.topl.brambl.utils.Encoding
-import co.topl.brambl.wallet.WalletApi
 import co.topl.bridge.Fellowship
 import co.topl.bridge.SystemGlobalState
 import co.topl.bridge.Template
-import co.topl.bridge.managers.TransactionAlgebra
 import co.topl.bridge.managers.WalletApiHelpers
 import co.topl.genus.services.Txo
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.typelevel.log4cats.Logger
 import quivr.models.Int128
-import quivr.models.KeyPair
-import co.topl.brambl.models.SeriesId
-import co.topl.brambl.models.GroupId
 
 import scala.concurrent.duration._
-import cats.effect.kernel.Resource
-import io.grpc.ManagedChannel
-import org.bitcoins.rpc.client.common.BitcoindRpcClient
 
 trait InitializationModuleAlgebra[F[_]] {
 
@@ -45,18 +38,12 @@ object InitializationModule {
       currentState: Ref[F, SystemGlobalState]
   )(implicit
       bitcoind: BitcoindRpcClient,
-      keyPair: KeyPair,
       tba: TransactionBuilderApi[F],
       wsa: WalletStateAlgebra[F],
-      wa: WalletApi[F],
-      genusQueryAlgebra: GenusQueryAlgebra[F],
-      channelResource: Resource[F, ManagedChannel]
+      genusQueryAlgebra: GenusQueryAlgebra[F]
   ) = new InitializationModuleAlgebra[F] {
 
     import WalletApiHelpers._
-    import SeriesMintingOps._
-    import GroupMintingOps._
-    import TransactionAlgebra._
 
     import org.typelevel.log4cats.syntax._
 
@@ -310,7 +297,7 @@ object InitializationModule {
           error"Retrying in 5 seconds" >>
           Async[F].sleep(
             5.second
-          ) >> setupWallet(fromFellowship, fromTemplate)
+          ) >> setupWallet(fromFellowship, fromTemplate, groupId, seriesId)
       }
     }
 

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/package.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/package.scala
@@ -4,6 +4,7 @@ import _root_.quivr.models.Int128
 
 package object bridge {
 
+  class BTCRetryThreshold(val underlying: Int) extends AnyVal
   class BTCWaitExpirationTime(val underlying: Int) extends AnyVal
   class ToplWaitExpirationTime(val underlying: Int) extends AnyVal
   class BTCConfirmationThreshold(val underlying: Int) extends AnyVal

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/package.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/package.scala
@@ -6,32 +6,7 @@ package object bridge {
 
   class BTCWaitExpirationTime(val underlying: Int) extends AnyVal
   class ToplWaitExpirationTime(val underlying: Int) extends AnyVal
-
-  object implicits {
-    // implicit class for BTCWaitExpirationTime that implements <, >, <=, >=, ==, != with integers
-    implicit class BTCWaitExpirationTimeOps(
-        val btcWaitExpirationTime: BTCWaitExpirationTime
-    ) {
-      def <(other: Long): Boolean = btcWaitExpirationTime.underlying < other
-      def >(other: Long): Boolean = btcWaitExpirationTime.underlying > other
-      def <=(other: Long): Boolean = btcWaitExpirationTime.underlying <= other
-      def >=(other: Long): Boolean = btcWaitExpirationTime.underlying >= other
-      def ==(other: Long): Boolean = btcWaitExpirationTime.underlying == other
-      def !=(other: Long): Boolean = btcWaitExpirationTime.underlying != other
-    }
-
-    // implicit class for ToplWaitExpirationTime that implements <, >, <=, >=, ==, != with integers
-    implicit class ToplWaitExpirationTimeOps(
-        val toplWaitExpirationTime: ToplWaitExpirationTime
-    ) {
-      def <(other: Long): Boolean = toplWaitExpirationTime.underlying < other
-      def >(other: Long): Boolean = toplWaitExpirationTime.underlying > other
-      def <=(other: Long): Boolean = toplWaitExpirationTime.underlying <= other
-      def >=(other: Long): Boolean = toplWaitExpirationTime.underlying >= other
-      def ==(other: Long): Boolean = toplWaitExpirationTime.underlying == other
-      def !=(other: Long): Boolean = toplWaitExpirationTime.underlying != other
-    }
-  }
+  class BTCConfirmationThreshold(val underlying: Int) extends AnyVal
 
   class Fellowship(val underlying: String) extends AnyVal
 

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/package.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/package.scala
@@ -8,6 +8,7 @@ package object bridge {
   class ToplWaitExpirationTime(val underlying: Int) extends AnyVal
   class BTCConfirmationThreshold(val underlying: Int) extends AnyVal
 
+
   class Fellowship(val underlying: String) extends AnyVal
 
   class Template(val underlying: String) extends AnyVal

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/BlockProcessor.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/BlockProcessor.scala
@@ -20,59 +20,104 @@ object BlockProcessor {
   }
 
   def process[F[_]](
-      block: Either[BitcoinBlockSync, BifrostMonitor.BifrostBlockSync]
-  ): fs2.Stream[F, BlockchainEvent] = block match {
-    case Left(b) =>
-      fs2.Stream(NewBTCBlock(b.height)) ++ fs2.Stream(
-        b.block.transactions.flatMap(transaction =>
-          transaction.inputs.map(input =>
-            BTCFundsWithdrawn(
-              input.previousOutput.txIdBE.hex,
-              input.previousOutput.vout.toLong
+      initialBTCHeight: Int,
+      initialToplHeight: Long
+  ): Either[BitcoinBlockSync, BifrostMonitor.BifrostBlockSync] => fs2.Stream[
+    F,
+    BlockchainEvent
+  ] = {
+    var btcHeight = initialBTCHeight
+    var toplHeight = initialToplHeight
+    var ascending = false
+    def processAux[F[_]](
+        block: Either[BitcoinBlockSync, BifrostMonitor.BifrostBlockSync]
+    ): fs2.Stream[F, BlockchainEvent] = block match {
+      case Left(b) =>
+        val allTransactions = fs2.Stream(
+          b.block.transactions.flatMap(transaction =>
+            transaction.inputs.map(input =>
+              BTCFundsWithdrawn(
+                input.previousOutput.txIdBE.hex,
+                input.previousOutput.vout.toLong
+              )
             )
-          )
-        ) ++ b.block.transactions.flatMap(transaction =>
-          transaction.outputs.zipWithIndex.map { outputAndVout =>
-            val (output, vout) = outputAndVout
-            BTCFundsDeposited(
-              b.height,
-              output.scriptPubKey,
-              transaction.txIdBE.hex,
-              vout.toLong,
-              output.value
-            )
-          }
-        ): _*
-      )
-    case Right(b) =>
-      fs2.Stream(NewToplBlock(b.height)) ++ fs2.Stream(
-        b.block.transactions.flatMap(transaction =>
-          transaction.inputs
-            .filter(x => isLvlSeriesGroupOrAsset(x.value.value))
-            .map { input =>
-              BifrostFundsWithdrawn(
-                Encoding.encodeToBase58(input.address.id.value.toByteArray()),
-                input.address.index,
-                Try(extractFromToplTx(input.attestation))
-                  .getOrElse(""), // TODO: Make this safer
-                toCurrencyUnit(input.value.value)
+          ) ++ b.block.transactions.flatMap(transaction =>
+            transaction.outputs.zipWithIndex.map { outputAndVout =>
+              val (output, vout) = outputAndVout
+              BTCFundsDeposited(
+                b.height,
+                output.scriptPubKey,
+                transaction.txIdBE.hex,
+                vout.toLong,
+                output.value
               )
             }
-        ) ++ b.block.transactions.flatMap(transaction =>
-          transaction.outputs.zipWithIndex.map { outputAndIdx =>
-            val (output, idx) = outputAndIdx
-            val bifrostCurrencyUnit = toCurrencyUnit(output.value.value)
-            BifrostFundsDeposited(
-              b.height,
-              AddressCodecs.encodeAddress(output.address),
-              Encoding.encodeToBase58(
-                transaction.transactionId.get.value.toByteArray()
-              ),
-              idx,
-              bifrostCurrencyUnit
+          ): _*
+        )
+        val transactions =
+          if (b.height == (btcHeight + 1)) { // going up as expected, include all transaction
+            btcHeight = b.height
+            ascending = true
+            allTransactions
+          } else if (b.height == (btcHeight - 1)) { // going down by one, we ommit transactions
+            ascending = false
+            fs2.Stream()
+          } else if (b.height > (btcHeight + 1)) { // we went up by more than one
+            ascending = true
+            fs2.Stream(
+              SkippedBTCBlock(b.height)
             )
+          } else if (b.height < (btcHeight - 1)) { // we went down by more than one, we ommit transactions
+            ascending = false
+            fs2.Stream()
+          } else {
+            // we stayed the same
+            if (ascending) {
+              // if we are ascending, it means the current block was just unapplied
+              // we don't pass the transactions that we have already seen
+              ascending = false
+              fs2.Stream()
+            } else {
+              // if we are descending, it means the current block was just applied
+              // we need to pass all transactions
+              ascending = true
+              allTransactions
+            }
           }
-        ): _*
-      )
+        fs2.Stream(NewBTCBlock(b.height)) ++ transactions
+      case Right(b) =>
+        fs2.Stream(NewToplBlock(b.height)) ++ fs2.Stream(
+          b.block.transactions.flatMap(transaction =>
+            transaction.inputs
+              .filter(x => isLvlSeriesGroupOrAsset(x.value.value))
+              .map { input =>
+                BifrostFundsWithdrawn(
+                  Encoding.encodeToBase58(input.address.id.value.toByteArray()),
+                  input.address.index,
+                  Try(extractFromToplTx(input.attestation))
+                    .getOrElse(""), // TODO: Make this safer
+                  toCurrencyUnit(input.value.value)
+                )
+              }
+          ) ++ b.block.transactions.flatMap(transaction =>
+            transaction.outputs.zipWithIndex.map { outputAndIdx =>
+              val (output, idx) = outputAndIdx
+              val bifrostCurrencyUnit = toCurrencyUnit(output.value.value)
+              BifrostFundsDeposited(
+                b.height,
+                AddressCodecs.encodeAddress(output.address),
+                Encoding.encodeToBase58(
+                  transaction.transactionId.get.value.toByteArray()
+                ),
+                idx,
+                bifrostCurrencyUnit
+              )
+            }
+          ): _*
+        )
+    }
+    processAux
+
   }
+
 }

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/BlockProcessor.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/BlockProcessor.scala
@@ -27,7 +27,7 @@ object BlockProcessor {
     BlockchainEvent
   ] = {
     var btcHeight = initialBTCHeight
-    var toplHeight = initialToplHeight
+    var toplHeight = initialToplHeight // FIXME: This will be used for the topl reorgs
     var ascending = false
     def processAux[F[_]](
         block: Either[BitcoinBlockSync, BifrostMonitor.BifrostBlockSync]

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/BlockProcessor.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/BlockProcessor.scala
@@ -35,6 +35,7 @@ object BlockProcessor {
           transaction.outputs.zipWithIndex.map { outputAndVout =>
             val (output, vout) = outputAndVout
             BTCFundsDeposited(
+              b.height,
               output.scriptPubKey,
               transaction.txIdBE.hex,
               vout.toLong,

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/DataTypes.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/DataTypes.scala
@@ -12,6 +12,7 @@ case class NewBTCBlock(height: Int) extends BlockchainEvent
 case class NewToplBlock(height: Long) extends BlockchainEvent
 
 case class BTCFundsDeposited(
+    fundsDepositedHeight: Int,
     scriptPubKey: ScriptPubKey,
     txId: String,
     vout: Long,
@@ -45,6 +46,7 @@ case class WaitingForBTC(
 
 case class WaitingForEscrowBTCConfirmation(
     startBTCBlockHeight: Int,
+    depositBTCBlockHeight: Int,
     currentWalletIdx: Int,
     scriptAsm: String,
     escrowAddress: String,

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/DataTypes.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/DataTypes.scala
@@ -9,6 +9,8 @@ case class BTCFundsWithdrawn(txId: String, vout: Long) extends BlockchainEvent
 
 case class NewBTCBlock(height: Int) extends BlockchainEvent
 
+case class SkippedBTCBlock(height: Int) extends BlockchainEvent
+
 case class NewToplBlock(height: Long) extends BlockchainEvent
 
 case class BTCFundsDeposited(
@@ -76,13 +78,31 @@ case class WaitingForRedemption(
     btcTxId: String,
     btcVout: Long,
     utxoTxId: String,
-    utxoIndex: Int
+    utxoIndex: Int,
+    amount: BifrostCurrencyUnit
 ) extends PeginStateMachineState
 
-case class WaitingForClaim(claimAddress: String) extends PeginStateMachineState
+case class WaitingForClaim(
+    someStartBtcBlockHeight: Option[Int],
+    secret: String,
+    currentWalletIdx: Int,
+    btcTxId: String,
+    btcVout: Long,
+    scriptAsm: String,
+    amount: BifrostCurrencyUnit,
+    claimAddress: String
+) extends PeginStateMachineState
 
-case class WaitingForClaimBTCConfirmation(claimBTCBlockHeight: Int, claimAddress: String)
-    extends PeginStateMachineState
+case class WaitingForClaimBTCConfirmation(
+    claimBTCBlockHeight: Int,
+    secret: String,
+    currentWalletIdx: Int,
+    btcTxId: String,
+    btcVout: Long,
+    scriptAsm: String,
+    amount: BifrostCurrencyUnit,
+    claimAddress: String
+) extends PeginStateMachineState
 
 sealed trait FSMTransition
 

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/DataTypes.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/DataTypes.scala
@@ -5,8 +5,7 @@ import org.bitcoins.core.protocol.script.ScriptPubKey
 
 sealed trait BlockchainEvent
 
-case class BTCFundsWithdrawn(txId: String, vout: Long)
-    extends BlockchainEvent
+case class BTCFundsWithdrawn(txId: String, vout: Long) extends BlockchainEvent
 
 case class NewBTCBlock(height: Int) extends BlockchainEvent
 
@@ -43,6 +42,19 @@ case class WaitingForBTC(
     redeemAddress: String,
     claimAddress: String
 ) extends PeginStateMachineState
+
+case class WaitingForEscrowBTCConfirmation(
+    startBTCBlockHeight: Int,
+    currentWalletIdx: Int,
+    scriptAsm: String,
+    escrowAddress: String,
+    redeemAddress: String,
+    claimAddress: String,
+    btcTxId: String,
+    btcVout: Long,
+    amount: Long
+) extends PeginStateMachineState
+
 case class MintingTBTC(
     startBTCBlockHeight: Int,
     currentWalletIdx: Int,

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/DataTypes.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/DataTypes.scala
@@ -78,7 +78,11 @@ case class WaitingForRedemption(
     utxoTxId: String,
     utxoIndex: Int
 ) extends PeginStateMachineState
+
 case class WaitingForClaim(claimAddress: String) extends PeginStateMachineState
+
+case class WaitingForClaimBTCConfirmation(claimBTCBlockHeight: Int, claimAddress: String)
+    extends PeginStateMachineState
 
 sealed trait FSMTransition
 

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/DataTypes.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/DataTypes.scala
@@ -92,6 +92,6 @@ case class FSMTransitionTo[F[_]](
     effect: F[Unit]
 ) extends FSMTransition
 
-case class EndTrasition[F[_]](
+case class EndTransition[F[_]](
     effect: F[Unit]
 ) extends FSMTransition

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginStateMachine.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginStateMachine.scala
@@ -136,6 +136,15 @@ object PeginStateMachine {
           currentState,
           blockchainEvent
         )(transitionToEffect[F])
+          .orElse(
+            Some(
+              FSMTransitionTo(
+                currentState,
+                currentState,
+                transitionToEffect(currentState, blockchainEvent)
+              )
+            )
+          )
           .map(x =>
             x match {
               case EndTransition(effect) =>

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginStateMachine.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginStateMachine.scala
@@ -21,6 +21,7 @@ import co.topl.bridge.PeginSessionState.PeginSessionWaitingForEscrowBTCConfirmat
 import co.topl.bridge.PeginSessionState.PeginSessionWaitingForClaimBTCConfirmation
 import co.topl.bridge.Template
 import co.topl.bridge.ToplWaitExpirationTime
+import co.topl.bridge.BTCRetryThreshold
 import co.topl.bridge.managers.BTCWalletAlgebra
 import co.topl.bridge.managers.PeginSessionInfo
 import co.topl.bridge.managers.PegoutSessionInfo
@@ -74,6 +75,7 @@ object PeginStateMachine {
       defaultMintingFee: Lvl,
       btcWaitExpirationTime: BTCWaitExpirationTime,
       toplWaitExpirationTime: ToplWaitExpirationTime,
+      btcRetryThreshold: BTCRetryThreshold,
       btcConfirmationThreshold: BTCConfirmationThreshold,
       channelResource: Resource[F, ManagedChannel],
       groupIdIdentifier: GroupId,

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginStateMachine.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginStateMachine.scala
@@ -38,6 +38,9 @@ import java.util.Map.Entry
 import java.util.concurrent.ConcurrentHashMap
 import co.topl.bridge.BTCConfirmationThreshold
 
+import co.topl.brambl.models.SeriesId
+import co.topl.brambl.models.GroupId
+
 trait PeginStateMachineAlgebra[F[_]] {
 
   def handleBlockchainEventInContext(
@@ -72,7 +75,9 @@ object PeginStateMachine {
       btcWaitExpirationTime: BTCWaitExpirationTime,
       toplWaitExpirationTime: ToplWaitExpirationTime,
       btcConfirmationThreshold: BTCConfirmationThreshold,
-      channelResource: Resource[F, ManagedChannel]
+      channelResource: Resource[F, ManagedChannel],
+      groupIdIdentifier: GroupId,
+      seriesIdIdentifier: SeriesId
   ) = new PeginStateMachineAlgebra[F] {
 
     import org.typelevel.log4cats.syntax._
@@ -163,8 +168,10 @@ object PeginStateMachine {
       case _: WaitingForBTC        => PeginSessionStateWaitingForBTC
       case _: WaitingForRedemption => PeginSessionWaitingForRedemption
       case _: WaitingForClaim      => PeginSessionWaitingForClaim
-      case _: WaitingForEscrowBTCConfirmation => PeginSessionWaitingForEscrowBTCConfirmation
-      case _: WaitingForClaimBTCConfirmation => PeginSessionWaitingForClaimBTCConfirmation
+      case _: WaitingForEscrowBTCConfirmation =>
+        PeginSessionWaitingForEscrowBTCConfirmation
+      case _: WaitingForClaimBTCConfirmation =>
+        PeginSessionWaitingForClaimBTCConfirmation
     }
 
     def processTransition(sessionId: String, transition: FSMTransitionTo[F]) =

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginStateMachine.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginStateMachine.scala
@@ -170,7 +170,7 @@ object PeginStateMachine {
                 Sync[F].unit
             }
           )).collect({ case Some(value) =>
-          info"Processed blockchain event ${blockchainEvent.getClass().getSimpleName()}" >> value
+          debug"Processed blockchain event ${blockchainEvent.getClass().getSimpleName()}" >> value
         })
 
     }

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginStateMachine.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginStateMachine.scala
@@ -17,6 +17,8 @@ import co.topl.bridge.PeginSessionState.PeginSessionStateMintingTBTC
 import co.topl.bridge.PeginSessionState.PeginSessionStateWaitingForBTC
 import co.topl.bridge.PeginSessionState.PeginSessionWaitingForClaim
 import co.topl.bridge.PeginSessionState.PeginSessionWaitingForRedemption
+import co.topl.bridge.PeginSessionState.PeginSessionWaitingForEscrowBTCConfirmation
+import co.topl.bridge.PeginSessionState.PeginSessionWaitingForClaimBTCConfirmation
 import co.topl.bridge.Template
 import co.topl.bridge.ToplWaitExpirationTime
 import co.topl.bridge.managers.BTCWalletAlgebra
@@ -161,7 +163,8 @@ object PeginStateMachine {
       case _: WaitingForBTC        => PeginSessionStateWaitingForBTC
       case _: WaitingForRedemption => PeginSessionWaitingForRedemption
       case _: WaitingForClaim      => PeginSessionWaitingForClaim
-      case _: WaitingForEscrowBTCConfirmation => PeginSessionState.PeginSessionWaitingForEscrowBTCConfirmation
+      case _: WaitingForEscrowBTCConfirmation => PeginSessionWaitingForEscrowBTCConfirmation
+      case _: WaitingForClaimBTCConfirmation => PeginSessionWaitingForClaimBTCConfirmation
     }
 
     def processTransition(sessionId: String, transition: FSMTransitionTo[F]) =

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginStateMachine.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginStateMachine.scala
@@ -34,6 +34,7 @@ import quivr.models.KeyPair
 
 import java.util.Map.Entry
 import java.util.concurrent.ConcurrentHashMap
+import co.topl.bridge.BTCConfirmationThreshold
 
 trait PeginStateMachineAlgebra[F[_]] {
 
@@ -68,6 +69,7 @@ object PeginStateMachine {
       defaultMintingFee: Lvl,
       btcWaitExpirationTime: BTCWaitExpirationTime,
       toplWaitExpirationTime: ToplWaitExpirationTime,
+      btcConfirmationThreshold: BTCConfirmationThreshold,
       channelResource: Resource[F, ManagedChannel]
   ) = new PeginStateMachineAlgebra[F] {
 
@@ -159,6 +161,7 @@ object PeginStateMachine {
       case _: WaitingForBTC        => PeginSessionStateWaitingForBTC
       case _: WaitingForRedemption => PeginSessionWaitingForRedemption
       case _: WaitingForClaim      => PeginSessionWaitingForClaim
+      case _: WaitingForEscrowBTCConfirmation => PeginSessionState.PeginSessionWaitingForEscrowBTCConfirmation
     }
 
     def processTransition(sessionId: String, transition: FSMTransitionTo[F]) =

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginStateMachine.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginStateMachine.scala
@@ -131,7 +131,7 @@ object PeginStateMachine {
         )(transitionToEffect[F])
           .map(x =>
             x match {
-              case EndTrasition(effect) =>
+              case EndTransition(effect) =>
                 info"Session $sessionId ended successfully" >>
                   Sync[F].delay(map.remove(sessionId)) >>
                   sessionManager

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginStateMachine.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginStateMachine.scala
@@ -153,7 +153,8 @@ object PeginStateMachine {
                   sessionManager
                     .removeSession(sessionId)
                     .flatMap(_ => effect.asInstanceOf[F[Unit]])
-              case FSMTransitionTo(prevState, nextState, effect) =>
+              case FSMTransitionTo(prevState, nextState, effect)
+                  if (prevState != nextState) =>
                 info"Transitioning session $sessionId from ${currentState
                     .getClass()
                     .getSimpleName()} to ${nextState.getClass().getSimpleName()}" >>
@@ -165,6 +166,8 @@ object PeginStateMachine {
                       effect.asInstanceOf[F[Unit]]
                     )
                   )
+              case FSMTransitionTo(_, _, _) =>
+                Sync[F].unit
             }
           )).collect({ case Some(value) =>
           info"Processed blockchain event ${blockchainEvent.getClass().getSimpleName()}" >> value

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelation.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelation.scala
@@ -108,7 +108,7 @@ object PeginTransitionRelation {
           toplWaitExpirationTime.underlying < (ev.height - cs.currentTolpBlockHeight)
         )
           Some(
-            EndTrasition[F](
+            EndTransition[F](
               Async[F].unit
             )
           )
@@ -162,7 +162,7 @@ object PeginTransitionRelation {
         // check that the confirmation threshold has been passed
         if (isAboveThreshold(ev.height, cs.claimBTCBlockHeight))
           Some(
-            EndTrasition[F](
+            EndTransition[F](
               Async[F].unit
             )
           )
@@ -218,7 +218,7 @@ object PeginTransitionRelation {
           btcWaitExpirationTime.underlying < (ev.height - cs.currentBTCBlockHeight)
         )
           Some(
-            EndTrasition[F](
+            EndTransition[F](
               Async[F].unit
             )
           )
@@ -232,7 +232,7 @@ object PeginTransitionRelation {
           ev.height - cs.startBTCBlockHeight > btcWaitExpirationTime.underlying
         )
           Some(
-            EndTrasition[F](
+            EndTransition[F](
               Async[F].unit
             )
           )

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelation.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelation.scala
@@ -186,7 +186,7 @@ object PeginTransitionRelation {
               t2E(currentState, blockchainEvent)
             )
           )
-        else if (ev.height <= cs.depositBTCBlockHeight)
+        else if (ev.height <= cs.depositBTCBlockHeight) {
           // we are seeing the block where the transaction was found again
           // this can only mean that block is being unapplied
           Some(
@@ -203,8 +203,7 @@ object PeginTransitionRelation {
               t2E(currentState, blockchainEvent)
             )
           )
-        else
-          None
+        } else None
       case (
             cs: WaitingForClaimBTCConfirmation,
             ev: NewBTCBlock
@@ -449,13 +448,5 @@ object PeginTransitionRelation {
             _
           ) =>
         None // No transition
-    }).orElse(
-      Some(
-        FSMTransitionTo(
-          currentState,
-          currentState,
-          t2E(currentState, blockchainEvent)
-        )
-      )
-    )
+    })
 }

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelation.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelation.scala
@@ -115,17 +115,6 @@ object PeginTransitionRelation {
         )
           Some(
             EndTransition[F](
-              Async[F].delay(
-                println(
-                  "cs.currentTolpBlockHeight: " + cs.currentTolpBlockHeight
-                )
-              ) >>
-                Async[F].delay(println("ev.height: " + ev.height)) >>
-                Async[F].delay(
-                  println(
-                    "toplWaitExpirationTime: " + toplWaitExpirationTime.underlying
-                  )
-                ) >>
                 Async[F].unit
             )
           )

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelation.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelation.scala
@@ -149,7 +149,7 @@ object PeginTransitionRelation {
       groupId: GroupId,
       seriesId: SeriesId
   ): Option[FSMTransition] =
-    (currentState, blockchainEvent) match {
+    ((currentState, blockchainEvent) match {
       case (
             cs: WaitingForRedemption,
             ev: NewToplBlock
@@ -449,5 +449,13 @@ object PeginTransitionRelation {
             _
           ) =>
         None // No transition
-    }
+    }).orElse(
+      Some(
+        FSMTransitionTo(
+          currentState,
+          currentState,
+          t2E(currentState, blockchainEvent)
+        )
+      )
+    )
 }

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelation.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelation.scala
@@ -73,7 +73,7 @@ object PeginTransitionRelation {
             cs: WaitingForEscrowBTCConfirmation,
             newBTCBLock: NewBTCBlock
           ) =>
-        if (isAboveThreshold(newBTCBLock.height, cs.startBTCBlockHeight))
+        if (isAboveThreshold(newBTCBLock.height, cs.depositBTCBlockHeight))
           Async[F]
             .start(
               startMintingProcess[F](
@@ -119,7 +119,7 @@ object PeginTransitionRelation {
             ev: NewBTCBlock
           ) =>
         // check that the confirmation threshold has been passed
-        if (isAboveThreshold(ev.height, cs.startBTCBlockHeight))
+        if (isAboveThreshold(ev.height, cs.depositBTCBlockHeight))
           Some(
             FSMTransitionTo(
               currentState,
@@ -136,7 +136,7 @@ object PeginTransitionRelation {
               t2E(currentState, blockchainEvent)
             )
           )
-        else if (ev.height <= cs.startBTCBlockHeight)
+        else if (ev.height <= cs.depositBTCBlockHeight)
           // we are seeing the block where the transaction was found again
           // this can only mean that block is being unapplied
           Some(
@@ -170,7 +170,7 @@ object PeginTransitionRelation {
         } else None
       case (
             WaitingForClaim(claimAddress),
-            BTCFundsDeposited(scriptPubKey, _, _, _)
+            BTCFundsDeposited(_, scriptPubKey, _, _, _)
           ) =>
         val bech32Address = Bech32Address.fromString(claimAddress)
         if (scriptPubKey == bech32Address.scriptPubKey) {
@@ -242,6 +242,7 @@ object PeginTransitionRelation {
               currentState,
               WaitingForEscrowBTCConfirmation(
                 cs.currentBTCBlockHeight,
+                ev.fundsDepositedHeight,
                 cs.currentWalletIdx,
                 cs.scriptAsm,
                 cs.escrowAddress,

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelation.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelation.scala
@@ -62,9 +62,9 @@ object PeginTransitionRelation {
       case SkippedBTCBlock(height) =>
         error"Error the processor skipped block $height"
       case NewToplBlock(height) =>
-        info"New Topl block $height"
+        debug"New Topl block $height"
       case NewBTCBlock(height) =>
-        info"New BTC block $height"
+        debug"New BTC block $height"
       case _ =>
         Async[F].unit
     }) >>

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelation.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelation.scala
@@ -223,8 +223,7 @@ object PeginTransitionRelation {
                 depositBTCBlockHeight,
                 claimAddress
               ),
-              // FIXME: Remove this println
-              Async[F].delay(println("claimAddress: " + claimAddress)) >> t2E(
+              t2E(
                 currentState,
                 blockchainEvent
               )
@@ -264,16 +263,6 @@ object PeginTransitionRelation {
             be: BifrostFundsDeposited
           ) =>
         import co.topl.brambl.syntax._
-        // FIXME: Remove this println
-        println("groupId existing: " + Encoding.encodeToBase58(groupId.value.toByteArray))
-        println("seriesId existing: " + Encoding.encodeToBase58(seriesId.value.toByteArray))
-        be.amount match {
-          case AssetToken(groupId, seriesId, amount) => 
-            println("be.amount.groupId: " +  groupId)
-            println("be.amount.seriedId: " + seriesId)
-          case _ =>
-            println("be.amount is not AssetToken")
-        }
 
         if (
           cs.redeemAddress == be.address &&
@@ -297,10 +286,7 @@ object PeginTransitionRelation {
                 be.utxoTxId,
                 be.utxoIndex
               ),
-              // FIXME: Remove this println
-              Sync[F].delay(
-                println("cs.redeemAddress: " + cs.redeemAddress)
-              ) >> Sync[F].unit
+              Sync[F].unit
             )
           )
         } else None

--- a/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/WaitingForRedemptionOps.scala
+++ b/topl-btc-bridge/src/main/scala/co/topl/bridge/statemachine/pegin/WaitingForRedemptionOps.scala
@@ -73,7 +73,6 @@ object WaitingForRedemptionOps {
             bridgeSig
           )
         )
-      _ = println("txWit: " + txWit.hex)
       _ <- Async[F].start(
         Async[F].delay(bitcoindInstance.sendRawTransaction(txWit))
       )

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/controllers/SharedData.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/controllers/SharedData.scala
@@ -4,13 +4,19 @@ import co.topl.shared.ToplPrivatenet
 import co.topl.bridge.BTCWaitExpirationTime
 import co.topl.bridge.ToplWaitExpirationTime
 import co.topl.bridge.BTCConfirmationThreshold
+import co.topl.bridge.BTCRetryThreshold
 import co.topl.brambl.models.SeriesId
 import co.topl.brambl.models.GroupId
 import com.google.protobuf.ByteString
 import co.topl.brambl.utils.Encoding
+import org.typelevel.log4cats.SelfAwareStructuredLogger
+import cats.effect.IO
 
 trait SharedData {
 
+  implicit val logger: SelfAwareStructuredLogger[IO] =
+    org.typelevel.log4cats.slf4j.Slf4jLogger
+      .getLoggerFromName[IO]("test-logger")
   val testKey =
     "0295bb5a3b80eeccb1e38ab2cbac2545e9af6c7012cdc8d53bd276754c54fc2e4a"
 
@@ -50,6 +56,9 @@ trait SharedData {
 
   implicit val btcConfirmationThreshold: BTCConfirmationThreshold =
     new BTCConfirmationThreshold(6)
+
+  implicit val btcRetryThreshold: BTCRetryThreshold =
+    new BTCRetryThreshold(6)
 
   val testToplNetworkId = ToplPrivatenet
 

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/controllers/SharedData.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/controllers/SharedData.scala
@@ -3,6 +3,7 @@ package co.topl.bridge.controllers
 import co.topl.shared.ToplPrivatenet
 import co.topl.bridge.BTCWaitExpirationTime
 import co.topl.bridge.ToplWaitExpirationTime
+import co.topl.bridge.BTCConfirmationThreshold
 
 trait SharedData {
 
@@ -42,6 +43,9 @@ trait SharedData {
 
   implicit val toplWaitExpirationTime: ToplWaitExpirationTime =
     new ToplWaitExpirationTime(2000)
+
+  implicit val btcConfirmationThreshold: BTCConfirmationThreshold =
+    new BTCConfirmationThreshold(6)
 
   val testToplNetworkId = ToplPrivatenet
 

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/controllers/SharedData.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/controllers/SharedData.scala
@@ -4,6 +4,10 @@ import co.topl.shared.ToplPrivatenet
 import co.topl.bridge.BTCWaitExpirationTime
 import co.topl.bridge.ToplWaitExpirationTime
 import co.topl.bridge.BTCConfirmationThreshold
+import co.topl.brambl.models.SeriesId
+import co.topl.brambl.models.GroupId
+import com.google.protobuf.ByteString
+import co.topl.brambl.utils.Encoding
 
 trait SharedData {
 
@@ -48,5 +52,27 @@ trait SharedData {
     new BTCConfirmationThreshold(6)
 
   val testToplNetworkId = ToplPrivatenet
+
+  implicit val groupId: GroupId = GroupId(
+    ByteString.copyFrom(
+      Encoding
+        .decodeFromHex(
+          "fdae7b6ea08b7d5489c3573abba8b1765d39365b4e803c4c1af6b97cf02c54bf"
+        )
+        .toOption
+        .get
+    )
+  )
+
+  implicit val seriesId: SeriesId = SeriesId(
+    ByteString.copyFrom(
+      Encoding
+        .decodeFromHex(
+          "1ed1caaefda61528936051929c525a17a0d43ea6ae09592da06c9735d9416c03"
+        )
+        .toOption
+        .get
+    )
+  )
 
 }

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelationSpec.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelationSpec.scala
@@ -6,6 +6,7 @@ import co.topl.bridge.AssetToken
 import munit.CatsEffectSuite
 import org.bitcoins.core.protocol.Bech32Address
 import scala.annotation.nowarn
+import co.topl.brambl.utils.Encoding
 import co.topl.bridge.controllers.SharedData
 
 class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
@@ -410,8 +411,8 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
             utxoTxId = "utxoTxId",
             utxoIndex = 0,
             amount = AssetToken(
-              "groupId",
-              "seriesId",
+              Encoding.encodeToHex(groupId.value.toByteArray),
+              Encoding.encodeToHex(seriesId.value.toByteArray),
               100L
             ) // Assuming AssetToken is a valid BifrostCurrencyUnit
           )

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelationSpec.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelationSpec.scala
@@ -43,7 +43,7 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
       PeginTransitionRelation
         .handleBlockchainEvent[IO](
           WaitingForBTC(1, 1, "", escrowAddress, redeemAddress, claimAddress),
-          BTCFundsDeposited(escrowAddressPubkey, "txId", 0, 100.satoshis)
+          BTCFundsDeposited(2, escrowAddressPubkey, "txId", 0, 100.satoshis)
         )(transitionToEffect[IO](_, _))
         .get
         .asInstanceOf[FSMTransitionTo[IO]]
@@ -66,7 +66,7 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
             redeemAddress,
             claimAddress
           ),
-          BTCFundsDeposited(escrowAddressPubkey, "txId", 0, 100.satoshis)
+          BTCFundsDeposited(2, escrowAddressPubkey, "txId", 0, 100.satoshis)
         )(transitionToEffect[IO](_, _))
         .isEmpty
     )
@@ -244,7 +244,7 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
             utxoTxId = "bifrostTxId",
             utxoIndex = 0 // Added missing utxoIndex parameter
           ),
-          BTCFundsDeposited(escrowAddressPubkey, "txId", 0, 100.satoshis)
+          BTCFundsDeposited(2, escrowAddressPubkey, "txId", 0, 100.satoshis)
         )(transitionToEffect[IO](_, _))
         .isEmpty &&
         PeginTransitionRelation
@@ -273,7 +273,7 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
       PeginTransitionRelation
         .handleBlockchainEvent[IO](
           WaitingForClaim(claimAddress),
-          BTCFundsDeposited(claimAddressPubkey, "txId", 0, 100.satoshis)
+          BTCFundsDeposited(2, claimAddressPubkey, "txId", 0, 100.satoshis)
         )(transitionToEffect[IO](_, _))
         .get
         .isInstanceOf[EndTrasition[IO]]: @nowarn
@@ -287,7 +287,7 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
       PeginTransitionRelation
         .handleBlockchainEvent[IO](
           WaitingForClaim(claimAddress),
-          BTCFundsDeposited(escrowAddressPubkey, "txId", 0, 100.satoshis)
+          BTCFundsDeposited(2, escrowAddressPubkey, "txId", 0, 100.satoshis)
         )(transitionToEffect[IO](_, _))
         .isEmpty
     )
@@ -445,7 +445,7 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
             0,
             100
           ),
-          BTCFundsDeposited(escrowAddressPubkey, "txId", 0, 100.satoshis)
+          BTCFundsDeposited(2, escrowAddressPubkey, "txId", 0, 100.satoshis)
         )(transitionToEffect[IO](_, _))
         .isEmpty &&
         PeginTransitionRelation
@@ -476,6 +476,7 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
           WaitingForEscrowBTCConfirmation(
             1,
             1,
+            1,
             "",
             escrowAddress,
             redeemAddress,
@@ -493,6 +494,7 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
         PeginTransitionRelation
           .handleBlockchainEvent[IO](
             WaitingForEscrowBTCConfirmation(
+              1,
               1,
               1,
               "",
@@ -516,6 +518,7 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
       PeginTransitionRelation
         .handleBlockchainEvent[IO](
           WaitingForEscrowBTCConfirmation(
+            1,
             8,
             1,
             "",

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelationSpec.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelationSpec.scala
@@ -83,7 +83,7 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
           NewBTCBlock(102)
         )(transitionToEffect[IO](_, _))
         .get
-        .isInstanceOf[EndTrasition[IO]]: @nowarn)
+        .isInstanceOf[EndTransition[IO]]: @nowarn)
     )
   }
 
@@ -172,7 +172,7 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
           NewToplBlock(2002)
         )(transitionToEffect[IO](_, _))
         .get
-        .isInstanceOf[EndTrasition[IO]]: @nowarn
+        .isInstanceOf[EndTransition[IO]]: @nowarn
     )
   }
 
@@ -289,8 +289,29 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
     )
   }
 
+  // WaitingForClaimBTCConfirmation -> EndTransition when timeout
   test(
-    "PeginTransitionRelation should not transition from WaitingForClaim to EndTrasition when the address is different"
+    "PeginTransitionRelation should transition from WaitingForClaimBTCConfirmation to EndTransition when timeout"
+  ) {
+    assert(
+      (PeginTransitionRelation
+        .handleBlockchainEvent[IO](
+          WaitingForClaimBTCConfirmation(1, claimAddress),
+          NewBTCBlock(8)
+        )(transitionToEffect[IO](_, _))
+        .get
+        .isInstanceOf[EndTransition[IO]]: @nowarn) &&
+        PeginTransitionRelation
+          .handleBlockchainEvent[IO](
+            WaitingForClaimBTCConfirmation(1, claimAddress),
+            NewBTCBlock(7)
+          )(transitionToEffect[IO](_, _))
+          .isEmpty
+    )
+  }
+
+  test(
+    "PeginTransitionRelation should not transition from WaitingForClaim to EndTransition when the address is different"
   ) {
     assert(
       PeginTransitionRelation
@@ -359,7 +380,7 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
           NewBTCBlock(102)
         )(transitionToEffect[IO](_, _))
         .get
-        .isInstanceOf[EndTrasition[IO]]: @nowarn
+        .isInstanceOf[EndTransition[IO]]: @nowarn
     )
   }
 

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelationSpec.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelationSpec.scala
@@ -8,6 +8,7 @@ import org.bitcoins.core.protocol.Bech32Address
 import scala.annotation.nowarn
 import co.topl.brambl.utils.Encoding
 import co.topl.bridge.controllers.SharedData
+import co.topl.brambl.syntax._
 
 class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
 
@@ -124,7 +125,6 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
   test(
     "PeginTransitionRelation should transition from WaitingForRedemption to BifrostFundsWithdrawn"
   ) {
-    import co.topl.brambl.syntax._
     assert(
       PeginTransitionRelation
         .handleBlockchainEvent[IO](
@@ -137,7 +137,8 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
             btcTxId = "txId",
             btcVout = 0L,
             utxoTxId = "bifrostTxId",
-            utxoIndex = 0 // Added missing utxoIndex parameter
+            utxoIndex = 0, // Added missing utxoIndex parameter
+            amount = AssetToken("groupId", "seriesId", 100L)
           ),
           BifrostFundsWithdrawn(
             "bifrostTxId",
@@ -168,7 +169,8 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
             btcTxId = "txId",
             btcVout = 0L,
             utxoTxId = "bifrostTxId",
-            utxoIndex = 0 // Added missing utxoIndex parameter
+            utxoIndex = 0,
+            amount = AssetToken("groupId", "seriesId", 100L)
           ),
           NewToplBlock(2002)
         )(transitionToEffect[IO](_, _))
@@ -193,7 +195,8 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
             btcTxId = "txId",
             btcVout = 0L,
             utxoTxId = "bifrostTxId",
-            utxoIndex = 0 // Added missing utxoIndex parameter
+            utxoIndex = 0,
+            amount = AssetToken("groupId", "seriesId", 100L)
           ),
           BifrostFundsWithdrawn(
             "bifrostTxIdDifferent",
@@ -214,7 +217,8 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
               btcTxId = "txId",
               btcVout = 0L,
               utxoTxId = "bifrostTxId",
-              utxoIndex = 0 // Added missing utxoIndex parameter
+              utxoIndex = 0,
+              amount = AssetToken("groupId", "seriesId", 100L)
             ),
             BifrostFundsWithdrawn(
               "bifrostTxId",
@@ -243,7 +247,8 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
             btcTxId = "txId",
             btcVout = 0L,
             utxoTxId = "bifrostTxId",
-            utxoIndex = 0 // Added missing utxoIndex parameter
+            utxoIndex = 0,
+            amount = AssetToken("groupId", "seriesId", 100L)
           ),
           BTCFundsDeposited(2, escrowAddressPubkey, "txId", 0, 100.satoshis)
         )(transitionToEffect[IO](_, _))
@@ -259,7 +264,8 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
               btcTxId = "txId",
               btcVout = 0L,
               utxoTxId = "bifrostTxId",
-              utxoIndex = 0 // Added missing utxoIndex parameter
+              utxoIndex = 0,
+              amount = AssetToken("groupId", "seriesId", 100L)
             ),
             BTCFundsWithdrawn("txId", 0)
           )(transitionToEffect[IO](_, _))
@@ -273,7 +279,22 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
     assert(
       PeginTransitionRelation
         .handleBlockchainEvent[IO](
-          WaitingForClaim(claimAddress),
+          WaitingForClaim(
+            someStartBtcBlockHeight =
+              None, // Assuming None if not specified, adjust as necessary
+            secret = "yourSecretHere", // Replace with actual secret
+            currentWalletIdx = 0, // Adjust according to your logic
+            btcTxId =
+              "yourBtcTxIdHere", // Replace with actual BTC transaction ID
+            btcVout = 0L, // Adjust as necessary
+            scriptAsm = "yourScriptAsmHere", // Replace with actual script ASM
+            amount = AssetToken(
+              "groupId",
+              "seriesId",
+              100L
+            ), // Adjust amount as necessary
+            claimAddress = claimAddress
+          ),
           BTCFundsDeposited(2, claimAddressPubkey, "txId", 0, 100.satoshis)
         )(transitionToEffect[IO](_, _))
         .get
@@ -283,7 +304,23 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
         &&
           PeginTransitionRelation
             .handleBlockchainEvent[IO](
-              WaitingForClaim(claimAddress),
+              WaitingForClaim(
+                someStartBtcBlockHeight =
+                  None, // Assuming None if not specified, adjust as necessary
+                secret = "yourSecretHere", // Replace with actual secret
+                currentWalletIdx = 0, // Adjust according to your logic
+                btcTxId =
+                  "yourBtcTxIdHere", // Replace with actual BTC transaction ID
+                btcVout = 0L, // Adjust as necessary
+                scriptAsm =
+                  "yourScriptAsmHere", // Replace with actual script ASM
+                amount = AssetToken(
+                  "groupId",
+                  "seriesId",
+                  100L
+                ), // Adjust amount as necessary
+                claimAddress = claimAddress
+              ),
               BTCFundsDeposited(2, escrowAddressPubkey, "txId", 0, 100.satoshis)
             )(transitionToEffect[IO](_, _))
             .isEmpty
@@ -297,14 +334,32 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
     assert(
       (PeginTransitionRelation
         .handleBlockchainEvent[IO](
-          WaitingForClaimBTCConfirmation(1, claimAddress),
+          WaitingForClaimBTCConfirmation(
+            1,
+            "secret",
+            1,
+            "btcTxId",
+            0,
+            "scriptAsm",
+            AssetToken("groupId", "seriesId", 100L),
+            claimAddress
+          ),
           NewBTCBlock(8)
         )(transitionToEffect[IO](_, _))
         .get
         .isInstanceOf[EndTransition[IO]]: @nowarn) &&
         PeginTransitionRelation
           .handleBlockchainEvent[IO](
-            WaitingForClaimBTCConfirmation(1, claimAddress),
+            WaitingForClaimBTCConfirmation(
+              1,
+              "secret",
+              1,
+              "btcTxId",
+              0,
+              "scriptAsm",
+              AssetToken("groupId", "seriesId", 100L),
+              claimAddress
+            ),
             NewBTCBlock(7)
           )(transitionToEffect[IO](_, _))
           .isEmpty
@@ -317,7 +372,22 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
     assert(
       PeginTransitionRelation
         .handleBlockchainEvent[IO](
-          WaitingForClaim(claimAddress),
+          WaitingForClaim(
+            someStartBtcBlockHeight =
+              None, // Assuming None if not specified, adjust as necessary
+            secret = "yourSecretHere", // Replace with actual secret
+            currentWalletIdx = 0, // Adjust according to your logic
+            btcTxId =
+              "yourBtcTxIdHere", // Replace with actual BTC transaction ID
+            btcVout = 0L, // Adjust as necessary
+            scriptAsm = "yourScriptAsmHere", // Replace with actual script ASM
+            amount = AssetToken(
+              "groupId",
+              "seriesId",
+              100L
+            ), // Adjust amount as necessary
+            claimAddress = claimAddress
+          ),
           BTCFundsDeposited(2, escrowAddressPubkey, "txId", 0, 100.satoshis)
         )(transitionToEffect[IO](_, _))
         .isEmpty
@@ -332,7 +402,22 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
     assert(
       PeginTransitionRelation
         .handleBlockchainEvent[IO](
-          WaitingForClaim(claimAddress),
+          WaitingForClaim(
+            someStartBtcBlockHeight =
+              None, // Assuming None if not specified, adjust as necessary
+            secret = "yourSecretHere", // Replace with actual secret
+            currentWalletIdx = 0, // Adjust according to your logic
+            btcTxId =
+              "yourBtcTxIdHere", // Replace with actual BTC transaction ID
+            btcVout = 0L, // Adjust as necessary
+            scriptAsm = "yourScriptAsmHere", // Replace with actual script ASM
+            amount = AssetToken(
+              "groupId",
+              "seriesId",
+              100L
+            ), // Adjust amount as necessary
+            claimAddress = claimAddress
+          ),
           BifrostFundsDeposited(
             currentToplBlockHeight =
               0L, // Assuming a missing parameter needs to be added
@@ -349,7 +434,22 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
         .isEmpty &&
         PeginTransitionRelation
           .handleBlockchainEvent[IO](
-            WaitingForClaim(claimAddress),
+            WaitingForClaim(
+              someStartBtcBlockHeight =
+                None, // Assuming None if not specified, adjust as necessary
+              secret = "yourSecretHere", // Replace with actual secret
+              currentWalletIdx = 0, // Adjust according to your logic
+              btcTxId =
+                "yourBtcTxIdHere", // Replace with actual BTC transaction ID
+              btcVout = 0L, // Adjust as necessary
+              scriptAsm = "yourScriptAsmHere", // Replace with actual script ASM
+              amount = AssetToken(
+                "groupId",
+                "seriesId",
+                100L
+              ), // Adjust amount as necessary
+              claimAddress = claimAddress
+            ),
             BifrostFundsWithdrawn(
               "bifrostTxId",
               0,

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelationSpec.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelationSpec.scala
@@ -601,6 +601,23 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
   test(
     "PeginTransitionRelation should transition from WaitingForEscrowBTCConfirmation to MintingTBTC"
   ) {
+            println (PeginTransitionRelation
+          .handleBlockchainEvent[IO](
+            WaitingForEscrowBTCConfirmation(
+              1,
+              1,
+              1,
+              "",
+              escrowAddress,
+              redeemAddress,
+              claimAddress,
+              "btcTxId",
+              0,
+              100
+            ),
+            NewBTCBlock(7)
+          )(transitionToEffect[IO](_, _))
+          )
     assert(
       PeginTransitionRelation
         .handleBlockchainEvent[IO](
@@ -621,24 +638,7 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
         .get
         .asInstanceOf[FSMTransitionTo[IO]]
         .nextState
-        .isInstanceOf[MintingTBTC] &&
-        PeginTransitionRelation
-          .handleBlockchainEvent[IO](
-            WaitingForEscrowBTCConfirmation(
-              1,
-              1,
-              1,
-              "",
-              escrowAddress,
-              redeemAddress,
-              claimAddress,
-              "btcTxId",
-              0,
-              100
-            ),
-            NewBTCBlock(7)
-          )(transitionToEffect[IO](_, _))
-          .isEmpty
+        .isInstanceOf[MintingTBTC]
     )
   }
   // WaitingForEscrowBTCConfirmation -> WaitingForBTC

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelationSpec.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelationSpec.scala
@@ -411,8 +411,8 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
             utxoTxId = "utxoTxId",
             utxoIndex = 0,
             amount = AssetToken(
-              Encoding.encodeToHex(groupId.value.toByteArray),
-              Encoding.encodeToHex(seriesId.value.toByteArray),
+              Encoding.encodeToBase58(groupId.value.toByteArray),
+              Encoding.encodeToBase58(seriesId.value.toByteArray),
               100L
             ) // Assuming AssetToken is a valid BifrostCurrencyUnit
           )

--- a/topl-btc-bridge/src/test/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelationSpec.scala
+++ b/topl-btc-bridge/src/test/scala/co/topl/bridge/statemachine/pegin/PeginTransitionRelationSpec.scala
@@ -267,7 +267,7 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
   }
 
   test(
-    "PeginTransitionRelation should transition from WaitingForClaim to EndTrasition"
+    "PeginTransitionRelation should transition from WaitingForClaim to WaitingForClaimBTCConfirmation"
   ) {
     assert(
       PeginTransitionRelation
@@ -276,7 +276,16 @@ class PeginTransitionRelationSpec extends CatsEffectSuite with SharedData {
           BTCFundsDeposited(2, claimAddressPubkey, "txId", 0, 100.satoshis)
         )(transitionToEffect[IO](_, _))
         .get
-        .isInstanceOf[EndTrasition[IO]]: @nowarn
+        .asInstanceOf[FSMTransitionTo[IO]]
+        .nextState
+        .isInstanceOf[WaitingForClaimBTCConfirmation]
+        &&
+          PeginTransitionRelation
+            .handleBlockchainEvent[IO](
+              WaitingForClaim(claimAddress),
+              BTCFundsDeposited(2, escrowAddressPubkey, "txId", 0, 100.satoshis)
+            )(transitionToEffect[IO](_, _))
+            .isEmpty
     )
   }
 


### PR DESCRIPTION
## Purpose

The goal of this task is to implement the BTC reorg sad path. 

## Approach

- Add new parameter `--btc-confirmation-threshold` to specify the number of confirmations needed for the deposit.
- Added parameters `--abtc-group-id` and `--abtc-series-id` to specify the group and series of the asset to mint.
- We now require the asset minted to be present at start time.
- Added auto retry for transactions that did not pass.

## Testing

- Add unit tests
- Add two integration tests
- Added heavy logging at the level of the State Machine
- Modify GH tests to run using two BTC nodes.
- Added resiliency to test cases.

## Tickets

* TSDK-812 TSDK-808

